### PR TITLE
Make sigaa-ai-agent installable with init wizard

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build
+        run: python -m pip install --upgrade build
+      - name: Build distributions
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -9,20 +9,27 @@ channels** persisted to SQLite with stable dedup by news id.
 
 ## Install
 
+Install `pipx` once if you do not already have it:
+
 ```bash
-python3 -m venv .venv && source .venv/bin/activate
-pip install -e ".[mcp,dev]"
+brew install pipx
+# or: python -m pip install --user pipx
+```
+
+Then install and run the setup wizard:
+
+```bash
+pipx install "sigaa-ai-agent[mcp]"
+sigaa init
 ```
 
 ## Credentials
 
-Keyring-first, env-second. Recommended:
+Run `sigaa init`. It prompts for your SIGAA username and password, stores the
+password in your OS keyring when available, verifies the login, runs the first
+sync, and can configure MCP and scheduled polling for you.
 
-```bash
-sigaa --user YOUR_USER login        # prompts, stores in macOS Keychain, verifies
-```
-
-Or headless via env: `export SIGAA_USER=... SIGAA_PASS=...`.
+Headless fallback: `export SIGAA_USER=... SIGAA_PASS=...`.
 Optional `SIGAA_DB=/path/to/sigaa.db` to override the store location.
 
 ## CLI
@@ -44,6 +51,36 @@ sigaa watch --interval 900 # foreground loop
 
 ## MCP server (for code agents)
 
+Run `sigaa init`; it can detect or create `.mcp.json` and add the `sigaa` MCP
+server without manual absolute-path editing.
+
+Tools: `sigaa_list_classes`, `sigaa_list_news`, `sigaa_get_news_body`,
+`sigaa_get_schedule`, `sigaa_list_grades`, `sigaa_list_deadlines`,
+`sigaa_export_ics`, `sigaa_download_historico`, `sigaa_sync`. Reads come from
+the store; `sigaa_sync` and `sigaa_download_historico` touch the network.
+
+## Scheduled polling
+
+Run `sigaa init`; it can write the launchd plist on macOS or print the cron
+entry for other operating systems.
+
+## Contributing / dev install
+
+```bash
+git clone https://github.com/PucaVaz/sigaa-for-ai-agents.git
+cd sigaa-for-ai-agents
+python3 -m venv .venv && source .venv/bin/activate
+pip install -e ".[mcp,dev]"
+sigaa --user YOUR_USER login
+```
+
+## Advanced manual configuration
+
+Usually you should run `sigaa init`. The examples below are for manual setups,
+debugging, or custom automation.
+
+### Manual MCP
+
 Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
 
 ```json
@@ -57,14 +94,9 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
 }
 ```
 
-Tools: `sigaa_list_classes`, `sigaa_list_news`, `sigaa_get_news_body`,
-`sigaa_get_schedule`, `sigaa_list_grades`, `sigaa_list_deadlines`,
-`sigaa_export_ics`, `sigaa_download_historico`, `sigaa_sync`. Reads come from
-the store; `sigaa_sync` and `sigaa_download_historico` touch the network.
+### Manual scheduled polling
 
-## Scheduled polling
-
-**macOS (launchd)** — sync every 30 min. Save as
+**macOS (launchd)** - sync every 30 min. Save as
 `~/Library/LaunchAgents/ai.sigaa.sync.plist` then
 `launchctl load` it:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,26 @@ version = "0.1.0"
 description = "User-friendly SIGAA UFPB client (CLI + MCP) for automation workflows"
 readme = "README.md"
 requires-python = ">=3.11"
+authors = [
+    { name = "Puca Vaz" },
+]
+keywords = ["sigaa", "ufpb", "mcp", "cli", "academic"]
+classifiers = [
+    "Environment :: Console",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
     "httpx>=0.27",
     "beautifulsoup4>=4.12",
     "lxml>=5.0",
     "keyring>=24",
 ]
+
+[project.urls]
+Homepage = "https://github.com/PucaVaz/sigaa-for-ai-agents"
+Repository = "https://github.com/PucaVaz/sigaa-for-ai-agents"
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0"]

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import argparse
-import getpass
 import json
 import sys
 import time
 from pathlib import Path
 
-from . import config
+from . import setup_wizard
 from .client import SigaaClient
 from .config import Settings
 from .exporters.ics import build_calendar
@@ -31,7 +30,11 @@ def main(argv: list[str] | None = None) -> int:
         settings.username = args.user
     if getattr(args, "db", None):
         settings.db_path = args.db
-    return args.func(args, settings)
+    try:
+        return args.func(args, settings)
+    except KeyboardInterrupt:
+        print("\nsetup cancelled", file=sys.stderr)
+        return 130
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -42,6 +45,9 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_login = sub.add_parser("login", help="store password in keychain and verify")
     p_login.set_defaults(func=_cmd_login)
+
+    p_init = sub.add_parser("init", help="interactive first-run setup wizard")
+    p_init.set_defaults(func=_cmd_init)
 
     p_sync = sub.add_parser("sync", help="fetch SIGAA and persist new news")
     p_sync.add_argument("--bodies", action="store_true", help="also fetch full news bodies")
@@ -111,21 +117,12 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _cmd_login(args, settings: Settings) -> int:
-    if not settings.username:
-        settings.username = input("SIGAA username: ").strip()
-    password = getpass.getpass("SIGAA password: ")
-    try:
-        import keyring
-
-        keyring.set_password(config.KEYRING_SERVICE, settings.username, password)
-        stored = "keychain"
-    except Exception:
-        stored = "not stored (keyring unavailable; use SIGAA_PASS env)"
-
-    with SigaaClient(settings.username, password) as client:
-        student = client.get_student()
-    print(f"login ok: {student.name} ({student.matricula}) — password {stored}")
+    setup_wizard.prompt_login(settings)
     return 0
+
+
+def _cmd_init(args, settings: Settings) -> int:
+    return setup_wizard.run_init(settings)
 
 
 def _cmd_sync(args, settings: Settings) -> int:

--- a/sigaa/setup_wizard.py
+++ b/sigaa/setup_wizard.py
@@ -1,0 +1,222 @@
+"""Interactive first-run setup and generated config helpers."""
+
+from __future__ import annotations
+
+import getpass
+import json
+import platform
+import shutil
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+from xml.sax.saxutils import escape
+
+from . import config
+from .client import SigaaClient
+from .config import Settings
+from .services.sync import sync
+
+
+@dataclass(frozen=True)
+class Institution:
+    key: str
+    label: str
+
+
+@dataclass(frozen=True)
+class LoginResult:
+    name: str
+    matricula: str
+    password_stored: bool
+    storage_message: str
+    password: str = field(repr=False)
+
+
+INSTITUTIONS = (Institution(key="ufpb", label="UFPB"),)
+
+
+def select_institution(input_func: Callable[[str], str] = input) -> Institution:
+    print("Institution:")
+    for index, institution in enumerate(INSTITUTIONS, start=1):
+        print(f"  {index}. {institution.label}")
+    answer = input_func("Choose institution [1]: ").strip()
+    if not answer:
+        return INSTITUTIONS[0]
+    try:
+        selected = INSTITUTIONS[int(answer) - 1]
+    except (ValueError, IndexError):
+        print(f"Unknown choice {answer!r}; using {INSTITUTIONS[0].label}.")
+        return INSTITUTIONS[0]
+    return selected
+
+
+def verify_and_store_login(username: str, password: str) -> LoginResult:
+    password_stored = True
+    storage_message = "password stored in keyring"
+    try:
+        import keyring
+
+        keyring.set_password(config.KEYRING_SERVICE, username, password)
+    except Exception:
+        password_stored = False
+        storage_message = "keyring unavailable; set SIGAA_PASS in your shell"
+
+    with SigaaClient(username, password) as client:
+        student = client.get_student()
+    return LoginResult(
+        name=student.name,
+        matricula=student.matricula,
+        password_stored=password_stored,
+        storage_message=storage_message,
+        password=password,
+    )
+
+
+def prompt_login(settings: Settings, input_func: Callable[[str], str] = input) -> LoginResult:
+    if not settings.username:
+        settings.username = input_func("SIGAA username: ").strip()
+    password = getpass.getpass("SIGAA password: ")
+    result = verify_and_store_login(settings.username, password)
+    print(f"login ok: {result.name} ({result.matricula}) - {result.storage_message}")
+    return result
+
+
+def resolve_script(name: str) -> str:
+    found = shutil.which(name)
+    if found:
+        return found
+    suffix = ".exe" if sys.platform == "win32" and not name.endswith(".exe") else ""
+    return str(Path(sys.executable).resolve().parent / f"{name}{suffix}")
+
+
+def merge_mcp_config(path: Path, *, command: str, username: str) -> bool:
+    path = path.expanduser()
+    if path.exists():
+        data = json.loads(path.read_text(encoding="utf-8"))
+    else:
+        data = {}
+    servers = data.setdefault("mcpServers", {})
+    desired = {"command": command, "env": {"SIGAA_USER": username}}
+    changed = servers.get("sigaa") != desired
+    servers["sigaa"] = desired
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return changed
+
+
+def build_launchd_plist(*, sigaa_cmd: str, username: str) -> str:
+    sigaa_cmd_xml = escape(sigaa_cmd)
+    username_xml = escape(username)
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"\n'
+        '  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0"><dict>\n'
+        "  <key>Label</key><string>ai.sigaa.sync</string>\n"
+        "  <key>ProgramArguments</key>\n"
+        "  <array>\n"
+        f"    <string>{sigaa_cmd_xml}</string>\n"
+        "    <string>sync</string>\n"
+        "  </array>\n"
+        "  <key>EnvironmentVariables</key>\n"
+        f"  <dict><key>SIGAA_USER</key><string>{username_xml}</string></dict>\n"
+        "  <key>StartInterval</key><integer>1800</integer>\n"
+        "</dict></plist>\n"
+    )
+
+
+def build_cron_line(*, sigaa_cmd: str, username: str) -> str:
+    return f"*/30 * * * * SIGAA_USER={username} {sigaa_cmd} sync"
+
+
+def write_env_template(path: Path, *, username: str) -> None:
+    path = path.expanduser()
+    path.write_text(
+        f"SIGAA_USER={username}\n"
+        "SIGAA_PASS=replace-with-your-password\n",
+        encoding="utf-8",
+    )
+
+
+def run_init(settings: Settings, input_func: Callable[[str], str] = input) -> int:
+    print("sigaa init")
+    institution = select_institution(input_func)
+    print(f"Using {institution.label}.")
+
+    login = _prompt_login_until_ok(settings, input_func)
+    if login is None:
+        return 1
+
+    print("Running first sync...")
+    result = sync(_sync_settings(settings, login))
+    if not result.ok:
+        print(f"sync failed: {result.error}", file=sys.stderr)
+        return 1
+    print(f"synced {result.turma_count} classes, {len(result.new_items)} news")
+
+    username = settings.username or ""
+    if not login.password_stored:
+        print("Keyring is unavailable on this machine.")
+        print("Set SIGAA_PASS in your environment before running network commands.")
+        if _confirm("Write a .env template without the password? [y/N]: ", input_func):
+            write_env_template(Path(".env"), username=username)
+            print("wrote .env template; fill SIGAA_PASS yourself and keep it private")
+
+    if _confirm("Wire MCP for Claude Code in .mcp.json? [y/N]: ", input_func):
+        default_mcp = Path.cwd() / ".mcp.json"
+        answer = input_func(f"MCP config path [{default_mcp}]: ").strip()
+        mcp_path = Path(answer).expanduser() if answer else default_mcp
+        command = resolve_script("sigaa-mcp")
+        merge_mcp_config(mcp_path, command=command, username=username)
+        print(f"wrote MCP server config to {mcp_path}")
+
+    if _confirm("Install scheduled sync? [y/N]: ", input_func):
+        _write_schedule(username=username)
+
+    _print_cheatsheet()
+    return 0
+
+
+def _prompt_login_until_ok(settings: Settings, input_func: Callable[[str], str]) -> LoginResult | None:
+    while True:
+        try:
+            return prompt_login(settings, input_func)
+        except Exception as exc:
+            print(f"login failed: {exc}", file=sys.stderr)
+            if not _confirm("Try again? [y/N]: ", input_func):
+                return None
+
+
+def _confirm(prompt: str, input_func: Callable[[str], str]) -> bool:
+    return input_func(prompt).strip().lower() in {"y", "yes", "s", "sim"}
+
+
+def _sync_settings(settings: Settings, login: LoginResult) -> Settings:
+    class InitSettings(Settings):
+        def resolve_password(self) -> str | None:
+            return login.password
+
+    return InitSettings(db_path=settings.db_path, username=settings.username)
+
+
+def _write_schedule(*, username: str) -> None:
+    sigaa_cmd = resolve_script("sigaa")
+    if platform.system() == "Darwin":
+        plist_path = Path.home() / "Library" / "LaunchAgents" / "ai.sigaa.sync.plist"
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text(build_launchd_plist(sigaa_cmd=sigaa_cmd, username=username), encoding="utf-8")
+        print(f"wrote {plist_path}")
+        print(f"load it with: launchctl load {plist_path}")
+        return
+    print("Add this cron entry:")
+    print(build_cron_line(sigaa_cmd=sigaa_cmd, username=username))
+    print("Password must come from keyring or SIGAA_PASS.")
+
+
+def _print_cheatsheet() -> None:
+    print("\nNext commands:")
+    print("  sigaa whatsnew")
+    print("  sigaa classes --schedule")
+    print("  sigaa news --unread")
+    print("  sigaa sync")

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+
+from sigaa.setup_wizard import (
+    build_cron_line,
+    build_launchd_plist,
+    merge_mcp_config,
+    resolve_script,
+)
+
+
+def test_merge_mcp_config_preserves_existing_servers(tmp_path):
+    path = tmp_path / ".mcp.json"
+    path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "other": {"command": "/bin/other"},
+                    "sigaa": {"command": "/old/sigaa-mcp", "env": {"SIGAA_USER": "old"}},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    changed = merge_mcp_config(path, command="/opt/bin/sigaa-mcp", username="alice")
+
+    assert changed is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["mcpServers"]["other"] == {"command": "/bin/other"}
+    assert data["mcpServers"]["sigaa"] == {
+        "command": "/opt/bin/sigaa-mcp",
+        "env": {"SIGAA_USER": "alice"},
+    }
+
+
+def test_merge_mcp_config_creates_parent_and_file(tmp_path):
+    path = tmp_path / "project" / ".mcp.json"
+
+    changed = merge_mcp_config(path, command="/opt/bin/sigaa-mcp", username="alice")
+
+    assert changed is True
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data == {
+        "mcpServers": {
+            "sigaa": {
+                "command": "/opt/bin/sigaa-mcp",
+                "env": {"SIGAA_USER": "alice"},
+            }
+        }
+    }
+
+
+def test_build_launchd_plist_uses_resolved_command_and_username():
+    plist = build_launchd_plist(sigaa_cmd="/opt/bin/sigaa", username="alice")
+
+    assert "<key>Label</key><string>ai.sigaa.sync</string>" in plist
+    assert "<string>/opt/bin/sigaa</string>" in plist
+    assert "<string>sync</string>" in plist
+    assert "<dict><key>SIGAA_USER</key><string>alice</string></dict>" in plist
+    assert "<key>StartInterval</key><integer>1800</integer>" in plist
+
+
+def test_build_cron_line_uses_resolved_command_and_username():
+    line = build_cron_line(sigaa_cmd="/opt/bin/sigaa", username="alice")
+
+    assert line == "*/30 * * * * SIGAA_USER=alice /opt/bin/sigaa sync"
+
+
+def test_resolve_script_prefers_path_lookup(monkeypatch):
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: f"/usr/local/bin/{name}")
+
+    assert resolve_script("sigaa-mcp") == "/usr/local/bin/sigaa-mcp"
+
+
+def test_resolve_script_falls_back_to_current_python_dir(monkeypatch):
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: None)
+    monkeypatch.setattr("sigaa.setup_wizard.sys.executable", "/opt/venv/bin/python")
+
+    assert resolve_script("sigaa-mcp") == str(Path("/opt/venv/bin/sigaa-mcp"))


### PR DESCRIPTION
## Summary
- Add a new sigaa init setup wizard with shared login verification, first sync, MCP config merge, and scheduled sync helpers.
- Add publish-ready package metadata and a tag-based PyPI trusted publishing workflow.
- Update README install docs for pipx + sigaa init and add offline setup wizard tests.

## Test Plan
- uv run --extra dev pytest -q
- /tmp/sigaa-build-venv/bin/python -m pip install build
- /tmp/sigaa-build-venv/bin/python -m build