### PR TITLE
docs: add public repository guidance

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Puca Vaz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # sigaa-ai-agent
 
+> [!IMPORTANT]
+> This is an unofficial personal project and is not affiliated with, endorsed
+> by, or supported by UFPB or SIGAA. Use it responsibly, keep request rates low,
+> and follow the rules that apply to your SIGAA account.
+
 User-friendly client for **SIGAA UFPB** (sigaa.ufpb.br) built for automation:
 a **CLI** and an **MCP server** over a layered Python core. Scope: single user.
 
@@ -16,7 +21,8 @@ pip install -e ".[mcp,dev]"
 
 ## Credentials
 
-Keyring-first, env-second. Recommended:
+Keyring-first, env-second. Never commit credentials, cookies, downloaded live
+HTML, SQLite databases, exported PDFs, or `.env` files. Recommended:
 
 ```bash
 sigaa --user YOUR_USER login        # prompts, stores in macOS Keychain, verifies
@@ -124,5 +130,11 @@ pytest        # offline: parsers run on fixtures, store on in-memory sqlite
 
 ## Security
 
-Single-user, but never commit credentials. `config.py` reads keyring then env.
-The SQLite db is local. `.gitignore` excludes `*.db`, `.env`, and live HTML dumps.
+Single-user, local-first tool. `config.py` reads credentials from keyring first
+and environment variables second. The SQLite db is local and may contain student
+data copied from SIGAA. `.gitignore` excludes `*.db`, `.env`, and live HTML
+dumps, but review generated files before sharing logs, issues, or screenshots.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "sigaa-ai-agent"
 version = "0.1.0"
 description = "User-friendly SIGAA UFPB client (CLI + MCP) for automation workflows"
 readme = "README.md"
+license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27",


### PR DESCRIPTION
## Summary
- Add an MIT license and package license metadata.
- Add an unofficial/no-affiliation disclaimer near the top of the README.
- Strengthen credential and local data handling guidance before making the repo public.

## Test Plan
- uv run pytest (49 passed)