### PR TITLE
feat: read tarefa details + download professor attachments

### DIFF
--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -130,6 +130,16 @@ class SigaaClient:
         body_html = self._session.post(config.AVA_URL, fields)
         return news_parser.parse_news_body(body_html)
 
+    def _open_event(self, event_id: str) -> str | None:
+        """Replay the portal deadline anchor's postback to render the event page."""
+        portal = self._portal()
+        fields = tarefa_parser.build_event_postback(
+            portal, event_id, extract_viewstate(portal)
+        )
+        if fields is None:
+            return None
+        return self._session.post(config.PORTAL_ACTION_URL, fields)
+
     def get_tarefa_body(self, event_id: str) -> dict | None:
         """Open a portal deadline event (tarefa/atividade) and scrape its details.
 
@@ -137,14 +147,29 @@ class SigaaClient:
         needed. Returns the detail rows as a dict, or None if the event has no
         scrapeable form (e.g. it is not a tarefa).
         """
-        portal = self._portal()
-        fields = tarefa_parser.build_event_postback(
-            portal, event_id, extract_viewstate(portal)
-        )
-        if fields is None:
+        html = self._open_event(event_id)
+        if html is None:
             return None
-        html = self._session.post(config.PORTAL_ACTION_URL, fields)
         return tarefa_parser.parse_tarefa_body(html)
+
+    def download_tarefa_attachment(self, event_id: str) -> tuple[bytes, str] | None:
+        """Download a tarefa's teacher attachment (Arquivo do Professor).
+
+        Returns (bytes, suggested filename), or None if the event has no
+        attachment. The filename falls back to the task's own name + extension.
+        """
+        html = self._open_event(event_id)
+        if html is None:
+            return None
+        href = tarefa_parser.find_professor_attachment(html)
+        if href is None:
+            return None
+        url = href if href.startswith("http") else config.HOST + href
+        content, content_type, disposition = self._session.get_download(url)
+        fields = tarefa_parser.parse_tarefa_body(html) or {}
+        title = fields.get("Nome da Tarefa") or f"tarefa-{event_id}"
+        filename = materials_parser.filename_for(title, content_type, disposition)
+        return content, filename
 
     def list_materials(self, turma: Turma, turma_html: str | None = None) -> list[Material]:
         html = turma_html or self.enter_turma(turma)

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -23,6 +23,7 @@ from .parsers import plano as plano_parser
 from .parsers import materials as materials_parser
 from .parsers import news as news_parser
 from .parsers import portal as portal_parser
+from .parsers import tarefa as tarefa_parser
 
 
 class SigaaClient:
@@ -128,6 +129,22 @@ class SigaaClient:
             return None
         body_html = self._session.post(config.AVA_URL, fields)
         return news_parser.parse_news_body(body_html)
+
+    def get_tarefa_body(self, event_id: str) -> dict | None:
+        """Open a portal deadline event (tarefa/atividade) and scrape its details.
+
+        The deadline's portal anchor carries the idTurma, so only the event id is
+        needed. Returns the detail rows as a dict, or None if the event has no
+        scrapeable form (e.g. it is not a tarefa).
+        """
+        portal = self._portal()
+        fields = tarefa_parser.build_event_postback(
+            portal, event_id, extract_viewstate(portal)
+        )
+        if fields is None:
+            return None
+        html = self._session.post(config.PORTAL_ACTION_URL, fields)
+        return tarefa_parser.parse_tarefa_body(html)
 
     def list_materials(self, turma: Turma, turma_html: str | None = None) -> list[Material]:
         html = turma_html or self.enter_turma(turma)

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -10,7 +10,8 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-BASE = "https://sigaa.ufpb.br/sigaa"
+HOST = "https://sigaa.ufpb.br"
+BASE = f"{HOST}/sigaa"
 LOGON_URL = f"{BASE}/logon.jsf"
 # Entry point that 302-redirects to the fully rendered beta portal. A plain GET
 # of the beta URL returns only a loading shell, so this slash-terminated classic

--- a/sigaa/http.py
+++ b/sigaa/http.py
@@ -78,6 +78,22 @@ class Session:
             resp.raise_for_status()
         return resp.content, resp.headers.get("content-type"), resp.headers.get("content-disposition")
 
+    def get_download(self, url: str) -> tuple[bytes, str | None, str | None]:
+        """GET a binary download; return (content, content-type, content-disposition).
+
+        Re-logins and retries once if the server bounces to an HTML login page.
+        """
+        if not self._authenticated:
+            self.login()
+        resp = self._client.request("GET", url)
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "")
+        if content_type.startswith("text/html") and self._looks_logged_out(resp.text):
+            self.login()
+            resp = self._client.request("GET", url)
+            resp.raise_for_status()
+        return resp.content, resp.headers.get("content-type"), resp.headers.get("content-disposition")
+
     def _request(self, method: str, url: str, data: dict | None = None) -> str:
         if not self._authenticated:
             self.login()

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -6,6 +6,8 @@ only networked tool. Run: ``python -m sigaa.mcp_server`` (stdio).
 
 from __future__ import annotations
 
+import json
+
 from mcp.server.fastmcp import FastMCP
 
 from .client import SigaaClient
@@ -262,6 +264,29 @@ def sigaa_list_deadlines(class_code: str | None = None) -> list[dict]:
          "date": d.date, "detail": d.detail}
         for d in repo.get_deadlines(id_turma=id_turma)
     ]
+
+
+@mcp.tool()
+def sigaa_get_tarefa_body(deadline_id: str) -> dict:
+    """Get a task/assignment's full details (Descrição, Período, ...) by its deadline id.
+    Served from cache; fetched live if missing. Run sigaa_sync first to learn ids."""
+    repo = _repo()
+    item = next((d for d in repo.get_deadlines() if d.id == deadline_id), None)
+    if item is None:
+        return {"error": f"deadline id {deadline_id} not found in store; run sigaa_sync first"}
+    if item.body:
+        return {"id": item.id, "title": item.title, "fields": json.loads(item.body)}
+
+    settings = Settings()
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        return {"error": "body not cached and no credentials available to fetch it"}
+    with SigaaClient(settings.username, password) as client:
+        fields = client.get_tarefa_body(deadline_id)
+    if not fields:
+        return {"error": "no detail form on this event (it may not be a tarefa)"}
+    repo.update_deadline_body(deadline_id, json.dumps(fields, ensure_ascii=False))
+    return {"id": item.id, "title": item.title, "fields": fields}
 
 
 @mcp.tool()

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -290,6 +290,30 @@ def sigaa_get_tarefa_body(deadline_id: str) -> dict:
 
 
 @mcp.tool()
+def sigaa_download_tarefa_anexo(deadline_id: str, path: str | None = None) -> str:
+    """Download a task's teacher attachment (Arquivo do Professor) by its deadline id.
+    Networked. Returns the path written, or a message if the task has no attachment."""
+    repo = _repo()
+    item = next((d for d in repo.get_deadlines() if d.id == deadline_id), None)
+    if item is None:
+        return f"deadline id {deadline_id} not found in store; run sigaa_sync first"
+
+    settings = Settings()
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        return "no credentials available"
+    with SigaaClient(settings.username, password) as client:
+        result = client.download_tarefa_attachment(deadline_id)
+    if result is None:
+        return "no teacher attachment on this task (or it is not a tarefa)"
+    content, filename = result
+    out = path or filename
+    with open(out, "wb") as fh:
+        fh.write(content)
+    return f"wrote {out} ({len(content)} bytes)"
+
+
+@mcp.tool()
 def sigaa_export_ics() -> str:
     """Return an iCalendar (.ics) feed of classes + deadlines from the store."""
     repo = _repo()

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -156,3 +156,5 @@ class Deadline:
     title: str
     date: str  # raw SIGAA date text, e.g. "Ter, 16/06" or "19/05 à 02/06"
     detail: str | None = None  # e.g. "em 10 dias"
+    # JSON of the scraped event detail rows (Descrição, Período, ...), cached on demand.
+    body: str | None = None

--- a/sigaa/parsers/tarefa.py
+++ b/sigaa/parsers/tarefa.py
@@ -1,0 +1,74 @@
+"""Open and scrape a portal deadline event (tarefa/atividade).
+
+Each deadline on a portal turma card is a dropdown anchor whose JSF postback
+navigates into the Turma Virtual and renders the event page — for a tarefa, the
+"Responder tarefa" form. We replay that postback (same form/field the browser
+posts), then read the ``label`` / ``div.campo`` rows it lays the details out in.
+"""
+
+from __future__ import annotations
+
+import re
+
+from bs4 import BeautifulSoup
+
+# jsfcljs(getElementById('<form>'),{'<field>':'<field>','id':'<event>','idTurma':'<turma>'},'')
+_ONCLICK_RE = re.compile(
+    r"getElementById\('([^']+)'\),\{'([^']+)':'[^']+','id':'(\d+)','idTurma':'(\d+)'"
+)
+# SIGAA renders this when a task is opened outside its submission window.
+_NOTICE_RE = re.compile(r"Esta tarefa só estará dispon", re.I)
+
+
+def build_event_postback(portal_html: str, event_id: str, viewstate: str) -> dict | None:
+    """Build the JSF POST that opens one portal event page, or None if absent."""
+    soup = BeautifulSoup(portal_html, "lxml")
+    for anchor in soup.select("a[onclick]"):
+        onclick = anchor.get("onclick", "")
+        if f"'id':'{event_id}'" not in onclick:
+            continue
+        match = _ONCLICK_RE.search(onclick)
+        if not match:
+            return None
+        form_id, field, _event, id_turma = match.groups()
+        return {
+            form_id: form_id,
+            field: field,
+            "id": event_id,
+            "idTurma": id_turma,
+            "javax.faces.ViewState": viewstate,
+        }
+    return None
+
+
+def parse_tarefa_body(html: str) -> dict | None:
+    """Scrape an event form's label/value rows (Descrição, Período, ...).
+
+    Returns the rows as a dict keyed by their (colon-stripped) label, or None if
+    the page carries no recognizable event detail form.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    form = _event_form(soup)
+    if form is None:
+        notice = soup.find(string=_NOTICE_RE)
+        if notice:
+            return {"Aviso": notice.strip()}
+        return None
+    fields: dict[str, str] = {}
+    for li in form.select("ul.form > li"):
+        label = li.find("label")
+        campo = li.find("div", class_="campo")
+        if label and campo:
+            key = label.get_text(" ", strip=True).rstrip(":").strip()
+            fields[key] = campo.get_text(" ", strip=True)
+    return fields or None
+
+
+def _event_form(soup: BeautifulSoup):
+    """The form holding the detail rows, found via its legend or its layout."""
+    for legend in soup.find_all("legend"):
+        text = legend.get_text(strip=True).casefold()
+        if "tarefa" in text or "atividade" in text or "respond" in text:
+            return legend.find_parent("form") or legend.parent
+    campo = soup.find("div", class_="campo")
+    return campo.find_parent("form") if campo else None

--- a/sigaa/parsers/tarefa.py
+++ b/sigaa/parsers/tarefa.py
@@ -18,6 +18,8 @@ _ONCLICK_RE = re.compile(
 )
 # SIGAA renders this when a task is opened outside its submission window.
 _NOTICE_RE = re.compile(r"Esta tarefa só estará dispon", re.I)
+# The "Arquivo do Professor" row links to the teacher's attached file.
+_ATTACHMENT_RE = re.compile(r"Baixar arquivo enviado", re.I)
 
 
 def build_event_postback(portal_html: str, event_id: str, viewstate: str) -> dict | None:
@@ -62,6 +64,17 @@ def parse_tarefa_body(html: str) -> dict | None:
             key = label.get_text(" ", strip=True).rstrip(":").strip()
             fields[key] = campo.get_text(" ", strip=True)
     return fields or None
+
+
+def find_professor_attachment(html: str) -> str | None:
+    """The href of the teacher's attached file on a tarefa page, or None."""
+    soup = BeautifulSoup(html, "lxml")
+    node = soup.find(string=_ATTACHMENT_RE)
+    if node is None:
+        return None
+    anchor = node.find_parent("a")
+    href = anchor.get("href") if anchor else None
+    return href or None
 
 
 def _event_form(soup: BeautifulSoup):

--- a/sigaa/store/db.py
+++ b/sigaa/store/db.py
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS deadline (
     title      TEXT,
     date       TEXT,
     detail     TEXT,
+    body       TEXT,
     is_new     INTEGER NOT NULL DEFAULT 1,
     fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
@@ -122,6 +123,9 @@ def _migrate(conn: sqlite3.Connection) -> None:
     """Additive migrations for stores created before a column existed."""
     if not _has_column(conn, "turma_grade", "is_new"):
         conn.execute("ALTER TABLE turma_grade ADD COLUMN is_new INTEGER NOT NULL DEFAULT 0")
+        conn.commit()
+    if not _has_column(conn, "deadline", "body"):
+        conn.execute("ALTER TABLE deadline ADD COLUMN body TEXT")
         conn.commit()
 
 

--- a/sigaa/store/repository.py
+++ b/sigaa/store/repository.py
@@ -302,6 +302,10 @@ class Repository:
         self._conn.commit()
         return is_new
 
+    def update_deadline_body(self, deadline_id: str, body: str) -> None:
+        self._conn.execute("UPDATE deadline SET body = ? WHERE id = ?", (body, deadline_id))
+        self._conn.commit()
+
     def get_deadlines(self, id_turma: str | None = None, unread_only: bool = False) -> list[Deadline]:
         clauses, params = [], []
         if id_turma:
@@ -414,5 +418,5 @@ def _attendance(row: sqlite3.Row) -> Attendance:
 def _deadline(row: sqlite3.Row) -> Deadline:
     return Deadline(
         id=row["id"], id_turma=row["id_turma"], kind=row["kind"], title=row["title"],
-        date=row["date"], detail=row["detail"],
+        date=row["date"], detail=row["detail"], body=row["body"],
     )

--- a/tests/fixtures/tarefa.html
+++ b/tests/fixtures/tarefa.html
@@ -20,6 +20,12 @@
             <div class="campo">Inicia em 15/06/2026 às 00h00 e finaliza em 20/06/2026 às 23h59</div>
           </li>
           <li>
+            <label>Arquivo do Professor:</label>
+            <div class="campo">
+              <a href="/sigaa/verFoto?idArquivo=9999999&amp;key=deadbeef">Baixar arquivo enviado pelo professor</a>
+            </div>
+          </li>
+          <li>
             <label>Arquivo:<span class="required"></span></label>
             <input id="formResponder:idArquivo" name="formResponder:idArquivo" type="file"/>
           </li>

--- a/tests/fixtures/tarefa.html
+++ b/tests/fixtures/tarefa.html
@@ -1,0 +1,31 @@
+<!-- Trimmed, anonymized sample of the Turma Virtual page rendered after opening
+     a tarefa event from the portal deadline dropdown. -->
+<html>
+  <body>
+    <form action="/sigaa/ava/TarefaTurma/enviarTarefa.jsf" id="formResponder" method="post">
+      <fieldset>
+        <legend>Responder tarefa</legend>
+        <input name="formResponder:id" type="hidden" value="11112222"/>
+        <ul class="form">
+          <li>
+            <label>Nome da Tarefa:</label>
+            <div class="campo">Atividade Exemplo</div>
+          </li>
+          <li>
+            <label>Descrição:</label>
+            <div class="campo">Enunciado da atividade de exemplo.</div>
+          </li>
+          <li>
+            <label>Período:</label>
+            <div class="campo">Inicia em 15/06/2026 às 00h00 e finaliza em 20/06/2026 às 23h59</div>
+          </li>
+          <li>
+            <label>Arquivo:<span class="required"></span></label>
+            <input id="formResponder:idArquivo" name="formResponder:idArquivo" type="file"/>
+          </li>
+        </ul>
+      </fieldset>
+      <input id="javax.faces.ViewState" name="javax.faces.ViewState" type="hidden" value="abc123"/>
+    </form>
+  </body>
+</html>

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -122,3 +122,13 @@ def test_parse_tarefa_body_returns_notice_when_closed():
 
 def test_parse_tarefa_body_returns_none_when_empty():
     assert tarefa_parser.parse_tarefa_body("<html><body></body></html>") is None
+
+
+def test_find_professor_attachment_returns_href():
+    href = tarefa_parser.find_professor_attachment(TAREFA)
+    assert href == "/sigaa/verFoto?idArquivo=9999999&key=deadbeef"
+
+
+def test_find_professor_attachment_absent_returns_none():
+    html = "<html><body><a href='/x'>Outro link</a></body></html>"
+    assert tarefa_parser.find_professor_attachment(html) is None

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -2,11 +2,13 @@ from pathlib import Path
 
 from sigaa.parsers import news as news_parser
 from sigaa.parsers import portal as portal_parser
+from sigaa.parsers import tarefa as tarefa_parser
 from sigaa.parsers.schedule import decode_schedule
 
 FIXTURES = Path(__file__).parent / "fixtures"
 PORTAL = (FIXTURES / "portal.html").read_text(encoding="utf-8")
 TURMA = (FIXTURES / "turma.html").read_text(encoding="utf-8")
+TAREFA = (FIXTURES / "tarefa.html").read_text(encoding="utf-8")
 
 
 def test_parse_student():
@@ -91,3 +93,32 @@ def test_decode_schedule_strips_date_range():
     [s] = decode_schedule("7M2345 (27/04/2026 - 13/08/2026)")
     assert s.days == [7]
     assert s.slots == [2, 3, 4, 5]
+
+
+def test_build_event_postback_from_portal_anchor():
+    fields = tarefa_parser.build_event_postback(PORTAL, "45959072", "vs1")
+    assert fields is not None
+    assert fields["id"] == "45959072"
+    assert fields["idTurma"] == "369279"
+    assert fields["javax.faces.ViewState"] == "vs1"
+
+
+def test_build_event_postback_missing_event_returns_none():
+    assert tarefa_parser.build_event_postback(PORTAL, "00000000", "vs1") is None
+
+
+def test_parse_tarefa_body_reads_detail_rows():
+    fields = tarefa_parser.parse_tarefa_body(TAREFA)
+    assert fields["Nome da Tarefa"] == "Atividade Exemplo"
+    assert fields["Descrição"] == "Enunciado da atividade de exemplo."
+    assert "finaliza em 20/06/2026" in fields["Período"]
+
+
+def test_parse_tarefa_body_returns_notice_when_closed():
+    html = "<html><body><ul><li>Esta tarefa só estará disponível no período de X.</li></ul></body></html>"
+    fields = tarefa_parser.parse_tarefa_body(html)
+    assert fields["Aviso"].startswith("Esta tarefa só estará")
+
+
+def test_parse_tarefa_body_returns_none_when_empty():
+    assert tarefa_parser.parse_tarefa_body("<html><body></body></html>") is None


### PR DESCRIPTION
Two networked MCP tools for tasks/assignments, which the existing news-body path could not reach.

## `sigaa_get_tarefa_body(deadline_id)`

Fetches a task's full details — Nome da Tarefa, Descrição, Período — by its deadline id.

SIGAA exposes *tarefa* bodies only through the portal deadline dropdown's JSF postback, which navigates into the Turma Virtual and renders the "Responder tarefa" form.

- **`parsers/tarefa.py`** — `build_event_postback` replays the dropdown anchor's `jsfcljs` call; `parse_tarefa_body` scrapes the `label` / `div.campo` rows, falling back to the availability notice for closed tasks.
- **`client.get_tarefa_body`** — portal postback → parse.
- **Store** — `deadline` gains a cached `body` column (additive migration; cache-first, live on miss).

## `sigaa_download_tarefa_anexo(deadline_id, path=None)`

Downloads the "Arquivo do Professor" file attached to a task. The tarefa page links it as a plain GET href (`/sigaa/verFoto?idArquivo=…&key=…`).

- **`parsers/tarefa.find_professor_attachment`** — locate the download href.
- **`http.Session.get_download`** — authenticated binary GET with re-login retry (mirrors `post_download`).
- **`client.download_tarefa_attachment`** — open event, fetch bytes, name the file from the task title via the shared `materials.filename_for`.
- **`config.HOST`** — scheme+host for resolving root-relative links.

## Verification

- `pytest`: 62 passed (7 new) + anonymized `tarefa.html` fixture.
- Live: Marco 1 → `{Nome, Descrição, Período}`; closed task → availability notice; cached re-read = no network. Atividade 06 attachment → 133 KB PDF named from the task title; task with no attachment → graceful message.