### PR TITLE
docs: Mintlify docs — getting-started + CLI reference

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,0 +1,150 @@
+---
+title: "Referência do CLI"
+description: "Todos os comandos do sigaa, suas flags e o que cada um faz."
+---
+
+Uso geral:
+
+```bash
+sigaa [--user USUARIO] [--db CAMINHO] <comando> [opções]
+```
+
+| Flag global | Descrição |
+|---|---|
+| `--user` | sobrescreve o usuário do SIGAA (senão usa `SIGAA_USER`) |
+| `--db` | sobrescreve o caminho do SQLite (senão usa `SIGAA_DB` ou o padrão) |
+
+<Note>
+Só `login`, `sync`, `watch`, `historico`, `attendance`, `plan` e o download de
+materiais acessam a **rede**. O resto lê do **banco local**. Quase todo comando de
+leitura aceita `--json`.
+</Note>
+
+## Setup
+
+### `login`
+
+Pede a senha, guarda no keychain e valida no SIGAA. **Networked.**
+
+```bash
+sigaa --user SEU_USUARIO login
+```
+
+## Atualizar (networked)
+
+### `sync`
+
+Busca o SIGAA e grava as novidades no banco. Único "builder" de rede.
+
+| Flag | Descrição |
+|---|---|
+| `--bodies` | também busca o texto completo das notícias |
+| `--json` | saída em JSON |
+
+### `watch`
+
+Roda `sync` repetidamente num intervalo.
+
+| Flag | Descrição |
+|---|---|
+| `--interval N` | segundos entre syncs (padrão 900) |
+| `--bodies` | igual a `sync --bodies` |
+
+### `historico`
+
+Baixa o histórico acadêmico em PDF. **Networked.**
+
+| Flag | Descrição |
+|---|---|
+| `--out ARQ` | arquivo de saída (padrão `historico.pdf`) |
+
+## Ler do banco
+
+### `classes`
+
+Lista as turmas matriculadas.
+
+| Flag | Descrição |
+|---|---|
+| `--schedule` | decodifica os códigos de horário (ex.: `6M2345` → Sex, manhã) |
+| `--json` | saída em JSON |
+
+### `news`
+
+Lista as notícias das turmas.
+
+| Flag | Descrição |
+|---|---|
+| `--class CODIGO` | filtra por turma |
+| `--unread` | só as não lidas |
+| `--mark-seen` | marca como lidas após mostrar |
+| `--json` | saída em JSON |
+
+### `grades`
+
+Notas por semestre; com `--class`, mostra o detalhamento por turma (Ver Notas).
+
+| Flag | Descrição |
+|---|---|
+| `--semester S` | filtra por semestre (ex.: `2025.1`) |
+| `--class CODIGO` | detalhamento de uma turma (unidades, exame, resultado, faltas) |
+| `--json` | saída em JSON |
+
+### `deadlines`
+
+Lista os prazos de avaliações/tarefas.
+
+| Flag | Descrição |
+|---|---|
+| `--class CODIGO` | filtra por turma |
+| `--json` | saída em JSON |
+
+### `materials`
+
+Lista os materiais das turmas; baixa com `--download`/`--download-all` (**networked**).
+
+| Flag | Descrição |
+|---|---|
+| `--class CODIGO` | filtra por turma |
+| `--kind {file,link}` | filtra por tipo |
+| `--download ID` | baixa um material por id (networked) |
+| `--download-all` | baixa todos os arquivos (networked) |
+| `--dir DIR` | pasta de saída (padrão `.`) |
+| `--json` | saída em JSON |
+
+### `whatsnew`
+
+Feed unificado: notícias, materiais, prazos, notas e faltas ainda não vistos.
+
+| Flag | Descrição |
+|---|---|
+| `--mark-seen` | limpa os itens após mostrar |
+| `--json` | saída em JSON |
+
+### `ics`
+
+Exporta turmas + prazos como calendário `.ics`.
+
+| Flag | Descrição |
+|---|---|
+| `--out ARQ` | arquivo de saída (padrão: stdout) |
+
+## Por turma, ao vivo (networked)
+
+### `attendance`
+
+Mapa de frequência (faltas por data) de uma turma. Busca ao vivo no SIGAA.
+
+| Flag | Descrição |
+|---|---|
+| `--class CODIGO` | **obrigatório** |
+| `--json` | saída em JSON |
+
+### `plan`
+
+Plano de Curso: cronograma de aulas + datas de avaliação. Busca ao vivo no SIGAA.
+
+| Flag | Descrição |
+|---|---|
+| `--class CODIGO` | **obrigatório** |
+| `--json` | saída em JSON |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "SIGAA",
+  "colors": {
+    "primary": "#15803D",
+    "light": "#22C55E",
+    "dark": "#166534"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Começando",
+        "pages": ["introduction", "getting-started"]
+      },
+      {
+        "group": "Referência",
+        "pages": ["cli"]
+      }
+    ]
+  }
+}

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,81 @@
+---
+title: "Primeiros passos"
+description: "Instale o sigaa-ai-agent, faça login e rode o primeiro sync."
+---
+
+## Pré-requisitos
+
+- **Python 3.11+**
+- Uma conta no **SIGAA UFPB**
+
+## 1. Instalar
+
+<Steps>
+  <Step title="Clone o repositório">
+    ```bash
+    git clone https://github.com/PucaVaz/sigaa-for-ai-agents.git
+    cd sigaa-for-ai-agents
+    ```
+  </Step>
+  <Step title="Crie o ambiente virtual e instale">
+    ```bash
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip install -e ".[mcp,dev]"
+    ```
+    Isso disponibiliza o comando `sigaa`.
+  </Step>
+</Steps>
+
+## 2. Fazer login
+
+A senha é guardada no **keychain** do sistema (não vai pro disco em texto puro).
+
+```bash
+sigaa --user SEU_USUARIO login
+```
+
+O comando pede a senha, valida no SIGAA e mostra seu nome e matrícula se deu certo.
+
+<Accordion title="Sem keychain? Use variáveis de ambiente">
+Se o keychain não estiver disponível (ex.: servidor/headless), exporte as credenciais:
+
+```bash
+export SIGAA_USER=seu_usuario
+export SIGAA_PASS=sua_senha
+```
+
+Opcional: `export SIGAA_DB=/caminho/para/sigaa.db` muda onde o banco local fica.
+</Accordion>
+
+## 3. Primeiro sync
+
+`sync` é o **único** comando que acessa a rede. Ele busca tudo e grava no banco local.
+
+```bash
+sigaa sync
+```
+
+Saída de exemplo:
+
+```
+synced 6 classes, 18 grade rows — 3 new news, 2 new deadlines
+  news + [10/06/2026] Prova 2 remarcada
+  deadline + [16/06/2026] Entrega do projeto
+```
+
+## 4. Ver seus dados
+
+Tudo abaixo lê do banco local (instantâneo, offline):
+
+```bash
+sigaa classes --schedule     # turmas + horário da semana
+sigaa whatsnew               # tudo que mudou desde a última checada
+sigaa grades                 # notas por semestre
+sigaa deadlines              # prazos
+```
+
+<Tip>
+Rode `sigaa sync` de tempos em tempos (ou deixe `sigaa watch` rodando) pra manter o
+banco atualizado. Veja todos os comandos na [Referência do CLI](/cli).
+</Tip>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,33 @@
+---
+title: "Introdução"
+description: "O que é o sigaa-ai-agent e como ele funciona."
+---
+
+O **sigaa-ai-agent** é um cliente do **SIGAA UFPB** feito para automação: um **CLI**
+sobre um núcleo Python em camadas. Como o SIGAA não tem API oficial, ele entra pelo
+fluxo web (login com cookie + `ViewState`) e busca suas **turmas, notícias, notas,
+faltas, prazos, plano de curso e materiais** — guardando tudo num **SQLite local**.
+
+<Note>
+Só o comando `sigaa sync` acessa a rede. Todo o resto **lê do banco local**, então é
+rápido e funciona offline.
+</Note>
+
+## Como está organizado
+
+<CardGroup cols={2}>
+  <Card title="Primeiros passos" icon="rocket" href="/getting-started">
+    Instale, faça login e rode o primeiro sync em alguns minutos.
+  </Card>
+  <Card title="Referência do CLI" icon="terminal" href="/cli">
+    Todos os comandos, flags e o que cada um faz.
+  </Card>
+</CardGroup>
+
+## O que dá pra fazer hoje
+
+- Listar turmas e o **horário** decodificado da semana
+- Ver **notícias**, **notas** (gerais e por turma), **prazos** e **frequência**
+- Baixar **materiais** das turmas e o **histórico** acadêmico em PDF
+- Exportar um **calendário `.ics`** com aulas e prazos
+- Ver um feed **"what's new"** com tudo que mudou desde a última checada


### PR DESCRIPTION
## O que é

Primeira versão da doc no **Mintlify** (`docs/`), focada no **setup** e na **referência do CLI**.

**Páginas:**
- `introduction` — o que é o sigaa-ai-agent
- `getting-started` — instalar → login → primeiro sync (o foco)
- `cli` — referência completa dos 13 comandos + flags

**Decisões:**
- 📝 **Português** (público-alvo = aluno BR) — fácil reverter depois.
- 📦 Setup documenta o **fluxo manual atual** (clone + venv); pipx/PyPI e `sigaa init` ainda não estão no ar.
- 🚫 **MCP / "conectar no Claude Desktop" ficou de fora** de propósito (ainda não é turnkey).

**Preview local:** `cd docs && npx mint dev`