### PR TITLE
Add academic document downloads to CLI and MCP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,14 @@ venv/
 *.sqlite3
 .env
 .env.*
+/.codex/config.toml
 
 # Live SIGAA dumps (may contain personal data)
 /tmp/sigaa_*
 *.local.html
+/historico.pdf
+/declaracao-vinculo.pdf
+/atestado-matricula.html
 
 # OS / editor
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Optional `SIGAA_DB=/path/to/sigaa.db` to override the store location.
 ## CLI
 
 ```bash
-sigaa sync                 # hit SIGAA: persist new news, deadlines, grades (only networked cmd)
+sigaa sync                 # hit SIGAA: persist new news, deadlines, grades
 sigaa sync --bodies        # also fetch full news article text
 sigaa classes --schedule   # enrolled classes with decoded weekly schedule
 sigaa news --class DSCO00022   # news for one class, from the store
@@ -54,10 +54,13 @@ sigaa grades --semester 2025.1 # grades report by semester
 sigaa deadlines            # assessment/task due dates
 sigaa ics --out sigaa.ics  # export classes + deadlines as a calendar
 sigaa historico --out h.pdf # download the academic transcript PDF (networked)
+sigaa declaracao-vinculo --out declaracao-vinculo.pdf # enrollment declaration PDF (networked)
+sigaa atestado-matricula --out atestado-matricula.html # enrollment certificate HTML (networked)
 sigaa watch --interval 900 # foreground loop
 ```
 
-`sync` writes the store; everything else reads it (fast, offline).
+Store-backed listing commands are fast and offline. Login, sync/watch, live
+lookups, and downloads access SIGAA over the network.
 
 ## MCP server (for code agents)
 
@@ -66,8 +69,21 @@ server without manual absolute-path editing.
 
 Tools: `sigaa_list_classes`, `sigaa_list_news`, `sigaa_get_news_body`,
 `sigaa_get_schedule`, `sigaa_list_grades`, `sigaa_list_deadlines`,
-`sigaa_export_ics`, `sigaa_download_historico`, `sigaa_sync`. Reads come from
-the store; `sigaa_sync` and `sigaa_download_historico` touch the network.
+`sigaa_export_ics`, `sigaa_download_historico`,
+`sigaa_download_declaracao_vinculo`, `sigaa_download_atestado_matricula`,
+`sigaa_sync`. Store-backed reads are offline; sync, live lookups, and downloads
+touch the network.
+
+Document tools accept a safe filename (not an arbitrary path), never overwrite,
+and write under the app's private `downloads` directory. Set
+`SIGAA_DOWNLOAD_DIR` on the MCP server to choose another directory. A successful
+call returns both structured metadata (filename, MIME type, and size) and
+an opaque MCP `ResourceLink`. Clients that support resource links can present the
+document as an attachment or download; opening it reads the saved file through
+MCP without putting its bytes in the original tool response. The resource link is
+valid for the current server session, while the local file remains on disk. HTML
+certificates are exposed as download-only binary resources so an MCP client does
+not execute the report's active SIGAA markup inline.
 
 ## Scheduled polling
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -15,9 +15,10 @@ sigaa [--user USUARIO] [--db CAMINHO] <comando> [opções]
 | `--db` | sobrescreve o caminho do SQLite (senão usa `SIGAA_DB` ou o padrão) |
 
 <Note>
-Só `login`, `sync`, `watch`, `historico`, `attendance`, `plan` e o download de
-materiais acessam a **rede**. O resto lê do **banco local**. Quase todo comando de
-leitura aceita `--json`.
+`login`, `sync`, `watch`, `historico`, `declaracao-vinculo`,
+`atestado-matricula`, `attendance`, `plan` e o download de materiais acessam a
+**rede**. Os demais comandos leem do **banco local**. Quase todo comando de leitura
+aceita `--json`.
 </Note>
 
 ## Setup
@@ -34,7 +35,7 @@ sigaa --user SEU_USUARIO login
 
 ### `sync`
 
-Busca o SIGAA e grava as novidades no banco. Único "builder" de rede.
+Busca o SIGAA e grava as novidades no banco local.
 
 | Flag | Descrição |
 |---|---|
@@ -57,6 +58,27 @@ Baixa o histórico acadêmico em PDF. **Networked.**
 | Flag | Descrição |
 |---|---|
 | `--out ARQ` | arquivo de saída (padrão `historico.pdf`) |
+| `--force` | substitui o arquivo de saída se ele já existir |
+
+### `declaracao-vinculo`
+
+Baixa a declaração de vínculo em PDF. **Networked.**
+
+| Flag | Descrição |
+|---|---|
+| `--out ARQ` | arquivo de saída (padrão `declaracao-vinculo.pdf`) |
+| `--force` | substitui o arquivo de saída se ele já existir |
+
+### `atestado-matricula`
+
+Baixa o atestado de matrícula como HTML imprimível. Abra-o no navegador para
+imprimir; o arquivo carrega o estilo e as imagens oficiais do SIGAA pela rede.
+**Networked.**
+
+| Flag | Descrição |
+|---|---|
+| `--out ARQ` | arquivo de saída (padrão `atestado-matricula.html`) |
+| `--force` | substitui o arquivo de saída se ele já existir |
 
 ## Ler do banco
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -46,11 +46,21 @@ export SIGAA_PASS=sua_senha
 ```
 
 Opcional: `export SIGAA_DB=/caminho/para/sigaa.db` muda onde o banco local fica.
+`SIGAA_DOWNLOAD_DIR=/pasta/privada` escolhe onde as tools MCP gravam documentos.
 </Accordion>
+
+As tools MCP de documentos devolvem os metadados do arquivo e um `ResourceLink`
+opaco. Em clientes compatíveis, o histórico, a declaração ou o atestado aparece
+como recurso para abrir ou baixar. O conteúdo só é lido quando o recurso é aberto;
+o link dura pela sessão atual do servidor e o arquivo continua salvo em
+`SIGAA_DOWNLOAD_DIR`. Por segurança, o atestado HTML é oferecido como download
+binário, evitando que o cliente MCP execute o conteúdo ativo do SIGAA embutido.
 
 ## 3. Primeiro sync
 
-`sync` é o **único** comando que acessa a rede. Ele busca tudo e grava no banco local.
+`sync` acessa a rede para buscar as novidades e gravá-las no banco local. Login,
+consultas ao vivo e downloads também usam a rede; os comandos baseados no SQLite
+continuam funcionando offline.
 
 ```bash
 sigaa sync

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -9,8 +9,8 @@ fluxo web (login com cookie + `ViewState`) e busca suas **turmas, notícias, not
 faltas, prazos, plano de curso e materiais** — guardando tudo num **SQLite local**.
 
 <Note>
-Só o comando `sigaa sync` acessa a rede. Todo o resto **lê do banco local**, então é
-rápido e funciona offline.
+As listagens armazenadas no SQLite são rápidas e funcionam offline. Login,
+sync/watch, consultas ao vivo e downloads acessam o SIGAA pela rede.
 </Note>
 
 ## Como está organizado
@@ -28,6 +28,8 @@ rápido e funciona offline.
 
 - Listar turmas e o **horário** decodificado da semana
 - Ver **notícias**, **notas** (gerais e por turma), **prazos** e **frequência**
-- Baixar **materiais** das turmas e o **histórico** acadêmico em PDF
+- Baixar **materiais** das turmas
+- Baixar o **histórico** e a **declaração de vínculo** em PDF
+- Baixar o **atestado de matrícula** como HTML imprimível, com assets oficiais do SIGAA
 - Exportar um **calendário `.ics`** com aulas e prazos
 - Ver um feed **"what's new"** com tudo que mudou desde a última checada

--- a/docs/sigaa-exploration.md
+++ b/docs/sigaa-exploration.md
@@ -41,9 +41,9 @@ posts off the same cached `turma_html` without re-entering.
 | Minhas Notas (Relatório de Notas) | ✅ | All-semester grade tables. |
 | Turma event cards (Avaliação/Atividade) | ✅ | Deadlines with stable ids. |
 | Histórico acadêmico | ✅ | Full transcript as PDF (`get_historico_pdf` / `sigaa historico`). |
-| Atestado de Matrícula | 🟢 | HTML enrollment proof (nível, vínculo, curso, turmas). Easy parse. |
+| Atestado de Matrícula | ✅ | Printable HTML enrollment certificate with official SIGAA assets (`sigaa atestado-matricula` / `sigaa_download_atestado_matricula`). |
 | Meus Dados Pessoais | ⚪ | Profile fields. |
-| Declaração de Vínculo | ⚪ | Printable doc. |
+| Declaração de Vínculo | ✅ | Enrollment declaration as PDF (`sigaa declaracao-vinculo` / `sigaa_download_declaracao_vinculo`). |
 | Ver Comprovante de Matrícula | ⚪ | Enrollment receipt. |
 | Consultar Estrutura Curricular | ⚪ | Curriculum + pending CH (progress already on portal header). |
 
@@ -60,7 +60,7 @@ posts off the same cached `turma_html` without re-entering.
 3. ~~Plano de Curso~~ — ✅ done (`sigaa plan --class`). Page has no clock times, so
    `SLOT_TIMES_UNCONFIRMED` needs another source (official UFPB slot table or a
    browser capture of the timetable widget).
-4. **Atestado de Matrícula** → parse the HTML enrollment proof (🟢, low effort).
+4. ~~Atestado de Matrícula + Declaração de Vínculo~~ — ✅ done (native HTML + PDF downloads).
 5. ~~Ver Notas (per-turma)~~ — ✅ done (`sigaa grades --class`).
 6. **Tarefas parser** once a turma has real assignments (page reachable, currently empty).
 7. **Participantes parser** if roster data becomes useful.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 keywords = ["sigaa", "ufpb", "mcp", "cli", "academic"]
 classifiers = [
     "Environment :: Console",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
@@ -31,7 +30,7 @@ Homepage = "https://github.com/PucaVaz/sigaa-for-ai-agents"
 Repository = "https://github.com/PucaVaz/sigaa-for-ai-agents"
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.0"]
+mcp = ["mcp>=1.27,<2"]
 dev = ["pytest>=8.0"]
 
 [project.scripts]

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -11,7 +11,15 @@ from pathlib import Path
 from . import setup_wizard
 from .client import SigaaClient
 from .config import Settings
+from .documents import (
+    ATESTADO_MATRICULA,
+    DECLARACAO_VINCULO,
+    HISTORICO,
+    AcademicDocumentError,
+    write_academic_document,
+)
 from .exporters.ics import build_calendar
+from .http import AuthError
 from .parsers.schedule import day_name, decode_schedule
 from .services import whatsnew
 from .services.sync import sync
@@ -76,7 +84,32 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_hist = sub.add_parser("historico", help="download the academic transcript PDF (networked)")
     p_hist.add_argument("--out", default="historico.pdf", help="output file (default: historico.pdf)")
+    p_hist.add_argument("--force", action="store_true", help="overwrite an existing output file")
     p_hist.set_defaults(func=_cmd_historico)
+
+    p_decl = sub.add_parser(
+        "declaracao-vinculo",
+        help="download the enrollment declaration PDF (networked)",
+    )
+    p_decl.add_argument(
+        "--out",
+        default="declaracao-vinculo.pdf",
+        help="output file (default: declaracao-vinculo.pdf)",
+    )
+    p_decl.add_argument("--force", action="store_true", help="overwrite an existing output file")
+    p_decl.set_defaults(func=_cmd_academic_document, document_kind=DECLARACAO_VINCULO)
+
+    p_cert = sub.add_parser(
+        "atestado-matricula",
+        help="download the printable enrollment certificate HTML (networked)",
+    )
+    p_cert.add_argument(
+        "--out",
+        default="atestado-matricula.html",
+        help="output file (default: atestado-matricula.html)",
+    )
+    p_cert.add_argument("--force", action="store_true", help="overwrite an existing output file")
+    p_cert.set_defaults(func=_cmd_academic_document, document_kind=ATESTADO_MATRICULA)
 
     p_news = sub.add_parser("news", help="list news from the store")
     p_news.add_argument("--class", dest="klass", help="filter by class code")
@@ -260,15 +293,30 @@ def _cmd_ics(args, settings: Settings) -> int:
 
 
 def _cmd_historico(args, settings: Settings) -> int:
+    args.document_kind = HISTORICO
+    return _cmd_academic_document(args, settings)
+
+
+def _cmd_academic_document(args, settings: Settings) -> int:
+    if Path(args.out).expanduser().exists() and not args.force:
+        print(f"output already exists: {args.out} (pass --force to overwrite)", file=sys.stderr)
+        return 1
     password = settings.resolve_password()
     if not settings.username or not password:
         print("missing credentials (set SIGAA_USER and keyring/SIGAA_PASS)", file=sys.stderr)
         return 1
-    with SigaaClient(settings.username, password) as client:
-        pdf = client.get_historico_pdf()
-    with open(args.out, "wb") as fh:
-        fh.write(pdf)
-    print(f"wrote {args.out} ({len(pdf)} bytes)")
+    try:
+        with SigaaClient(settings.username, password) as client:
+            document = client.download_academic_document(args.document_kind)
+    except (AcademicDocumentError, AuthError, ValueError) as exc:
+        print(f"download failed: {exc}", file=sys.stderr)
+        return 1
+    try:
+        write_academic_document(document, args.out, overwrite=args.force)
+    except FileExistsError:
+        print(f"output already exists: {args.out} (pass --force to overwrite)", file=sys.stderr)
+        return 1
+    print(f"wrote {args.out} ({len(document.content)} bytes, {document.media_type})")
     return 0
 
 

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -85,7 +85,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_hist = sub.add_parser("historico", help="download the academic transcript PDF (networked)")
     p_hist.add_argument("--out", default="historico.pdf", help="output file (default: historico.pdf)")
     p_hist.add_argument("--force", action="store_true", help="overwrite an existing output file")
-    p_hist.set_defaults(func=_cmd_historico)
+    p_hist.set_defaults(func=_cmd_academic_document, document_kind=HISTORICO)
 
     p_decl = sub.add_parser(
         "declaracao-vinculo",
@@ -290,11 +290,6 @@ def _cmd_ics(args, settings: Settings) -> int:
     else:
         print(ics, end="")
     return 0
-
-
-def _cmd_historico(args, settings: Settings) -> int:
-    args.document_kind = HISTORICO
-    return _cmd_academic_document(args, settings)
 
 
 def _cmd_academic_document(args, settings: Settings) -> int:

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -5,7 +5,16 @@ from __future__ import annotations
 import re
 
 from . import config
-from .http import Session, extract_viewstate
+from .documents import (
+    ATESTADO_MATRICULA,
+    DECLARACAO_VINCULO,
+    HISTORICO,
+    AcademicDocument,
+    AcademicDocumentError,
+    document_spec,
+    validate_academic_document,
+)
+from .http import AuthError, Session, extract_viewstate
 from .models import (
     Attendance,
     CoursePlan,
@@ -52,26 +61,52 @@ class SigaaClient:
 
     def get_historico_pdf(self) -> bytes:
         """Download the full academic transcript (Histórico) as a PDF."""
-        portal = self._portal()
-        field = portal_parser.find_menu_field(portal, "Histórico acadêmico")
-        if field is None:
-            raise ValueError("Histórico menu item not found")
-        form_id = portal_parser.portal_form_id(portal)
-        fields = {form_id: form_id, field: field, "javax.faces.ViewState": extract_viewstate(portal)}
-        return self._session.post_bytes(config.PORTAL_ACTION_URL, fields)
+        return self.download_academic_document(HISTORICO).content
+
+    def get_declaracao_vinculo_pdf(self) -> bytes:
+        """Download the current enrollment declaration as a PDF."""
+        return self.download_academic_document(DECLARACAO_VINCULO).content
+
+    def get_atestado_matricula_html(self) -> bytes:
+        """Download the enrollment certificate as printable HTML."""
+        return self.download_academic_document(ATESTADO_MATRICULA).content
+
+    def download_academic_document(self, kind: str) -> AcademicDocument:
+        """Download and validate one document exposed on the student portal.
+
+        A session refresh changes the JSF component ids and ViewState.  If the
+        first response is an auth bounce or an unexpected page, log in once more
+        and rebuild the payload from the newly rendered portal before retrying.
+        """
+        spec = document_spec(kind)
+        last_error: AuthError | AcademicDocumentError | None = None
+        for attempt in range(2):
+            portal = self._portal()
+            fields = portal_parser.build_menu_postback(portal, spec.menu_label)
+            if fields is None:
+                raise ValueError(f"portal document menu item not found: {spec.menu_label!r}")
+            try:
+                content, content_type, disposition = self._session.post_download(
+                    config.PORTAL_ACTION_URL,
+                    fields,
+                    retry_on_auth=False,
+                )
+                return validate_academic_document(
+                    kind, content, content_type, disposition
+                )
+            except (AuthError, AcademicDocumentError) as exc:
+                last_error = exc
+                if attempt == 0:
+                    self._portal_html = self._session.login()
+        assert last_error is not None
+        raise last_error
 
     def _portal_menu_post(self, link_text: str) -> str:
         """Click a portal sidebar menu item by its visible text via JSF postback."""
         portal = self._portal()
-        field = portal_parser.find_menu_field(portal, link_text)
-        if field is None:
+        fields = portal_parser.build_menu_postback(portal, link_text)
+        if fields is None:
             raise ValueError(f"portal menu item not found: {link_text!r}")
-        form_id = portal_parser.portal_form_id(portal)
-        fields = {
-            form_id: form_id,
-            field: field,
-            "javax.faces.ViewState": extract_viewstate(portal),
-        }
         return self._session.post(config.PORTAL_ACTION_URL, fields)
 
     def enter_turma(self, turma: Turma) -> str:

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -79,27 +79,22 @@ class SigaaClient:
         and rebuild the payload from the newly rendered portal before retrying.
         """
         spec = document_spec(kind)
-        last_error: AuthError | AcademicDocumentError | None = None
         for attempt in range(2):
             portal = self._portal()
             fields = portal_parser.build_menu_postback(portal, spec.menu_label)
             if fields is None:
                 raise ValueError(f"portal document menu item not found: {spec.menu_label!r}")
             try:
-                content, content_type, disposition = self._session.post_download(
+                content, content_type, _ = self._session.post_download(
                     config.PORTAL_ACTION_URL,
                     fields,
                     retry_on_auth=False,
                 )
-                return validate_academic_document(
-                    kind, content, content_type, disposition
-                )
-            except (AuthError, AcademicDocumentError) as exc:
-                last_error = exc
-                if attempt == 0:
-                    self._portal_html = self._session.login()
-        assert last_error is not None
-        raise last_error
+                return validate_academic_document(kind, content, content_type)
+            except (AuthError, AcademicDocumentError):
+                if attempt == 1:
+                    raise
+                self._portal_html = self._session.login()
 
     def _portal_menu_post(self, link_text: str) -> str:
         """Click a portal sidebar menu item by its visible text via JSF postback."""

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -50,6 +50,14 @@ def default_db_path() -> Path:
     return base / "sigaa-ai-agent" / "sigaa.db"
 
 
+def default_download_dir() -> Path:
+    """Private directory used by MCP download tools (override via SIGAA_DOWNLOAD_DIR)."""
+    override = os.environ.get("SIGAA_DOWNLOAD_DIR")
+    if override:
+        return Path(override).expanduser()
+    return default_db_path().parent / "downloads"
+
+
 @dataclass
 class Settings:
     db_path: Path = field(default_factory=default_db_path)

--- a/sigaa/documents.py
+++ b/sigaa/documents.py
@@ -1,0 +1,232 @@
+"""Academic document contracts and response validation.
+
+SIGAA exposes these reports as JSF postbacks from the student portal.  Two are
+PDF downloads; the enrollment certificate is printable HTML. Keep response
+validation here so callers never write a successful HTTP 200 login/error page
+under a misleading extension.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tempfile
+import unicodedata
+from dataclasses import dataclass, field
+from email.message import Message
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+from .config import HOST
+
+HISTORICO = "historico"
+DECLARACAO_VINCULO = "declaracao-vinculo"
+ATESTADO_MATRICULA = "atestado-matricula"
+
+
+class AcademicDocumentError(RuntimeError):
+    """SIGAA did not return the requested academic document."""
+
+
+@dataclass(frozen=True)
+class AcademicDocumentSpec:
+    kind: str
+    menu_label: str
+    default_filename: str
+    media_type: str
+
+
+@dataclass(frozen=True)
+class AcademicDocument:
+    kind: str
+    filename: str
+    media_type: str
+    content: bytes = field(repr=False)
+    charset: str | None = None
+
+
+DOCUMENT_SPECS = {
+    HISTORICO: AcademicDocumentSpec(
+        kind=HISTORICO,
+        menu_label="Histórico acadêmico",
+        default_filename="historico.pdf",
+        media_type="application/pdf",
+    ),
+    DECLARACAO_VINCULO: AcademicDocumentSpec(
+        kind=DECLARACAO_VINCULO,
+        menu_label="Declaração de vínculo",
+        default_filename="declaracao-vinculo.pdf",
+        media_type="application/pdf",
+    ),
+    ATESTADO_MATRICULA: AcademicDocumentSpec(
+        kind=ATESTADO_MATRICULA,
+        menu_label="Atestado de matrícula",
+        default_filename="atestado-matricula.html",
+        media_type="text/html",
+    ),
+}
+
+_UNSAFE_FILENAME_RE = re.compile(r'[\\/:*?"<>|\x00-\x1f]+')
+_WINDOWS_RESERVED = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
+
+def document_spec(kind: str) -> AcademicDocumentSpec:
+    try:
+        return DOCUMENT_SPECS[kind]
+    except KeyError as exc:
+        choices = ", ".join(DOCUMENT_SPECS)
+        raise ValueError(f"unknown academic document {kind!r}; choose one of: {choices}") from exc
+
+
+def validate_academic_document(
+    kind: str,
+    content: bytes,
+    content_type: str | None,
+    content_disposition: str | None = None,
+) -> AcademicDocument:
+    """Validate a SIGAA response and attach safe download metadata."""
+    spec = document_spec(kind)
+    media_type, charset = _parse_content_type(content_type)
+
+    if spec.media_type == "application/pdf":
+        if media_type != "application/pdf" or not content.startswith(b"%PDF-"):
+            raise AcademicDocumentError(f"SIGAA did not return a valid PDF for {kind}")
+    else:
+        if media_type != "text/html":
+            raise AcademicDocumentError(f"SIGAA did not return HTML for {kind}")
+        _validate_atestado_html(content, charset)
+
+    if kind == ATESTADO_MATRICULA:
+        content = _with_sigaa_base_url(content)
+
+    filename = _filename_from_disposition(content_disposition) or spec.default_filename
+    return AcademicDocument(
+        kind=kind,
+        filename=filename,
+        media_type=media_type,
+        charset=charset,
+        content=content,
+    )
+
+
+def sanitize_download_filename(name: str) -> str:
+    """Reduce a server-supplied filename to one safe local path component."""
+    normalized = unicodedata.normalize("NFC", name).strip()
+    normalized = re.split(r"[/\\]", normalized)[-1]
+    normalized = _UNSAFE_FILENAME_RE.sub("_", normalized).strip().strip(".")
+    if not normalized:
+        return "documento"
+    stem = normalized.split(".", 1)[0].upper()
+    if stem in _WINDOWS_RESERVED:
+        normalized = f"_{normalized}"
+    if len(normalized) > 240:
+        base, dot, suffix = normalized.rpartition(".")
+        normalized = f"{base[:220]}{dot}{suffix[:16]}" if dot else normalized[:240]
+    return normalized
+
+
+def write_academic_document(
+    document: AcademicDocument,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Write private document bytes, atomically when replacing an existing file."""
+    target = Path(path).expanduser()
+    if overwrite:
+        _atomic_replace(target, document.content)
+    else:
+        _exclusive_write(target, document.content)
+    return target.resolve()
+
+
+def _exclusive_write(target: Path, content: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    descriptor = os.open(target, flags, 0o600)
+    try:
+        _write_descriptor(descriptor, content)
+    except BaseException:
+        target.unlink(missing_ok=True)
+        raise
+
+
+def _atomic_replace(target: Path, content: bytes) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        _write_descriptor(descriptor, content)
+        os.replace(temporary, target)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def _write_descriptor(descriptor: int, content: bytes) -> None:
+    with os.fdopen(descriptor, "wb") as handle:
+        handle.write(content)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _parse_content_type(value: str | None) -> tuple[str, str | None]:
+    if not value:
+        return "", None
+    message = Message()
+    message["Content-Type"] = value
+    media_type = message.get_content_type().lower()
+    charset = message.get_content_charset()
+    return media_type, charset.lower() if charset else None
+
+
+def _filename_from_disposition(value: str | None) -> str | None:
+    if not value:
+        return None
+    message = Message()
+    message["Content-Disposition"] = value
+    filename = message.get_filename()
+    return sanitize_download_filename(filename) if filename else None
+
+
+def _validate_atestado_html(content: bytes, charset: str | None) -> None:
+    if not content:
+        raise AcademicDocumentError("SIGAA returned an empty enrollment certificate")
+    encoding = charset or "iso-8859-1"
+    try:
+        html = content.decode(encoding)
+    except (LookupError, UnicodeDecodeError) as exc:
+        raise AcademicDocumentError("SIGAA returned an unreadable enrollment certificate") from exc
+
+    soup = BeautifulSoup(html, "lxml")
+    heading = soup.find("h3")
+    heading_text = heading.get_text(" ", strip=True).casefold() if heading else ""
+    required_ids = ("identificacao", "matriculas", "autenticacao")
+    if "atestado de matrícula" not in heading_text or any(
+        soup.find(id=element_id) is None for element_id in required_ids
+    ):
+        raise AcademicDocumentError("SIGAA returned an unexpected enrollment certificate page")
+
+
+_HEAD_RE = re.compile(br"(<head(?:\s[^>]*)?>)", re.IGNORECASE)
+
+
+def _with_sigaa_base_url(content: bytes) -> bytes:
+    """Make the saved report's root-relative official assets work under file://."""
+    if re.search(br"<base\s", content, re.IGNORECASE):
+        return content
+    base = f'<base href="{HOST}/">'.encode("ascii")
+    portable, replacements = _HEAD_RE.subn(rb"\1\n" + base, content, count=1)
+    if replacements != 1:
+        raise AcademicDocumentError("SIGAA returned an enrollment certificate without a head")
+    return portable

--- a/sigaa/documents.py
+++ b/sigaa/documents.py
@@ -31,16 +31,13 @@ class AcademicDocumentError(RuntimeError):
 
 @dataclass(frozen=True)
 class AcademicDocumentSpec:
-    kind: str
     menu_label: str
-    default_filename: str
     media_type: str
 
 
 @dataclass(frozen=True)
 class AcademicDocument:
     kind: str
-    filename: str
     media_type: str
     content: bytes = field(repr=False)
     charset: str | None = None
@@ -48,21 +45,15 @@ class AcademicDocument:
 
 DOCUMENT_SPECS = {
     HISTORICO: AcademicDocumentSpec(
-        kind=HISTORICO,
         menu_label="Histórico acadêmico",
-        default_filename="historico.pdf",
         media_type="application/pdf",
     ),
     DECLARACAO_VINCULO: AcademicDocumentSpec(
-        kind=DECLARACAO_VINCULO,
         menu_label="Declaração de vínculo",
-        default_filename="declaracao-vinculo.pdf",
         media_type="application/pdf",
     ),
     ATESTADO_MATRICULA: AcademicDocumentSpec(
-        kind=ATESTADO_MATRICULA,
         menu_label="Atestado de matrícula",
-        default_filename="atestado-matricula.html",
         media_type="text/html",
     ),
 }
@@ -90,9 +81,8 @@ def validate_academic_document(
     kind: str,
     content: bytes,
     content_type: str | None,
-    content_disposition: str | None = None,
 ) -> AcademicDocument:
-    """Validate a SIGAA response and attach safe download metadata."""
+    """Validate a SIGAA response and return its media metadata."""
     spec = document_spec(kind)
     media_type, charset = _parse_content_type(content_type)
 
@@ -107,10 +97,8 @@ def validate_academic_document(
     if kind == ATESTADO_MATRICULA:
         content = _with_sigaa_base_url(content)
 
-    filename = _filename_from_disposition(content_disposition) or spec.default_filename
     return AcademicDocument(
         kind=kind,
-        filename=filename,
         media_type=media_type,
         charset=charset,
         content=content,
@@ -188,15 +176,6 @@ def _parse_content_type(value: str | None) -> tuple[str, str | None]:
     media_type = message.get_content_type().lower()
     charset = message.get_content_charset()
     return media_type, charset.lower() if charset else None
-
-
-def _filename_from_disposition(value: str | None) -> str | None:
-    if not value:
-        return None
-    message = Message()
-    message["Content-Disposition"] = value
-    filename = message.get_filename()
-    return sanitize_download_filename(filename) if filename else None
 
 
 def _validate_atestado_html(content: bytes, charset: str | None) -> None:

--- a/sigaa/http.py
+++ b/sigaa/http.py
@@ -61,21 +61,34 @@ class Session:
         return content
 
     def post_download(
-        self, url: str, data: dict[str, str]
+        self,
+        url: str,
+        data: dict[str, str],
+        *,
+        retry_on_auth: bool = True,
     ) -> tuple[bytes, str | None, str | None]:
         """POST a binary download; return (content, content-type, content-disposition).
 
         Re-logins and retries once if the server bounces to an HTML login page.
+        Set ``retry_on_auth=False`` when the payload contains render-scoped JSF
+        ids: the caller must refresh the page and rebuild those fields instead.
         """
         if not self._authenticated:
             self.login()
         resp = self._client.request("POST", url, data=data)
         resp.raise_for_status()
         content_type = resp.headers.get("content-type", "")
-        if content_type.startswith("text/html") and self._looks_logged_out(resp.text):
+        if content_type.lower().startswith("text/html") and self._looks_logged_out(resp.text):
+            if not retry_on_auth:
+                self._authenticated = False
+                raise AuthError("session expired before download postback")
             self.login()
             resp = self._client.request("POST", url, data=data)
             resp.raise_for_status()
+            retry_type = resp.headers.get("content-type", "")
+            if retry_type.lower().startswith("text/html") and self._looks_logged_out(resp.text):
+                self._authenticated = False
+                raise AuthError("session lost and re-login did not restore it")
         return resp.content, resp.headers.get("content-type"), resp.headers.get("content-disposition")
 
     def get_download(self, url: str) -> tuple[bytes, str | None, str | None]:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -42,7 +42,6 @@ mcp = FastMCP("sigaa-ufpb")
 class _DocumentResource:
     path: Path
     download_dir: Path
-    filename: str
     media_type: str
     size: int
     sha256: str
@@ -519,7 +518,6 @@ def _register_document_resource(
     _DOCUMENT_RESOURCES[token] = _DocumentResource(
         path=resolved_path,
         download_dir=resolved_download_dir,
-        filename=filename,
         media_type=media_type,
         size=len(content),
         sha256=hashlib.sha256(content).hexdigest(),

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -1,17 +1,33 @@
 """MCP server exposing SIGAA to code agents.
 
-Reads are served from the local store (instant, offline). ``sigaa_sync`` is the
-only networked tool. Run: ``python -m sigaa.mcp_server`` (stdio).
+Most reads are served from the local store (instant, offline). Live class
+reports, sync, and explicit downloads touch SIGAA. Run:
+``python -m sigaa.mcp_server`` (stdio).
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import CallToolResult, ResourceLink, TextContent
 
 from .client import SigaaClient
-from .config import Settings
+from .config import Settings, default_download_dir
+from .documents import (
+    ATESTADO_MATRICULA,
+    DECLARACAO_VINCULO,
+    HISTORICO,
+    document_spec,
+    sanitize_download_filename,
+    write_academic_document,
+)
 from .exporters.ics import build_calendar
 from .parsers.schedule import day_name, decode_schedule
 from .services import whatsnew
@@ -20,6 +36,20 @@ from .store.db import connect
 from .store.repository import Repository
 
 mcp = FastMCP("sigaa-ufpb")
+
+
+@dataclass(frozen=True)
+class _DocumentResource:
+    path: Path
+    download_dir: Path
+    filename: str
+    media_type: str
+    size: int
+    sha256: str
+
+
+_DOCUMENT_RESOURCES: dict[str, _DocumentResource] = {}
+_RESOURCE_TOKEN_RE = re.compile(r"[A-Za-z0-9_-]{32}\Z")
 
 
 def _repo() -> Repository:
@@ -368,22 +398,183 @@ def _attendance_update(repo: Repository, a) -> dict:
 
 
 @mcp.tool()
-def sigaa_download_historico(path: str = "historico.pdf") -> str:
-    """Download the academic transcript PDF to a path. Networked. Returns the path."""
+def sigaa_download_historico(filename: str = "historico.pdf") -> CallToolResult:
+    """Download the transcript into the private MCP download directory."""
+    return _download_academic_document(HISTORICO, filename)
+
+
+@mcp.tool()
+def sigaa_download_declaracao_vinculo(
+    filename: str = "declaracao-vinculo.pdf",
+) -> CallToolResult:
+    """Download the declaration into the private MCP download directory."""
+    return _download_academic_document(DECLARACAO_VINCULO, filename)
+
+
+@mcp.tool()
+def sigaa_download_atestado_matricula(
+    filename: str = "atestado-matricula.html",
+) -> CallToolResult:
+    """Download the printable HTML into the private MCP download directory."""
+    return _download_academic_document(ATESTADO_MATRICULA, filename)
+
+
+def _download_academic_document(kind: str, filename: str) -> CallToolResult:
+    if (
+        not filename
+        or Path(filename).name != filename
+        or sanitize_download_filename(filename) != filename
+    ):
+        raise ToolError("filename must be one safe file name, not a path")
+
+    download_dir = default_download_dir().resolve()
+    target = download_dir / filename
+    if target.exists() or target.is_symlink():
+        raise ToolError(f"download already exists: {filename}")
+
     settings = Settings()
     password = settings.resolve_password()
     if not settings.username or not password:
-        return "no credentials available"
+        raise ToolError("no credentials available")
     with SigaaClient(settings.username, password) as client:
-        pdf = client.get_historico_pdf()
-    with open(path, "wb") as fh:
-        fh.write(pdf)
-    return f"wrote {path} ({len(pdf)} bytes)"
+        document = client.download_academic_document(kind)
+    download_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        written = write_academic_document(document, target)
+    except FileExistsError:
+        raise ToolError(f"download already exists: {filename}") from None
+
+    size = len(document.content)
+    resource_media_type = (
+        "application/octet-stream"
+        if document.media_type == "text/html"
+        else document.media_type
+    )
+    resource_uri = _register_document_resource(
+        written,
+        download_dir=download_dir,
+        filename=filename,
+        media_type=document.media_type,
+        content=document.content,
+    )
+    metadata = {
+        "kind": document.kind,
+        "filename": filename,
+        "mime_type": document.media_type,
+        "size": size,
+        "resource_uri": resource_uri,
+        "resource_mime_type": resource_media_type,
+    }
+    return CallToolResult(
+        content=[
+            TextContent(
+                type="text",
+                text=(
+                    f"Downloaded {filename} ({size} bytes). "
+                    "Open the attached MCP resource to view or save it."
+                ),
+            ),
+            ResourceLink(
+                type="resource_link",
+                name=filename,
+                title=document_spec(document.kind).menu_label,
+                uri=resource_uri,
+                description="Academic document downloaded from SIGAA",
+                mimeType=resource_media_type,
+                size=size,
+            ),
+        ],
+        structuredContent=metadata,
+    )
+
+
+def _register_document_resource(
+    path: Path,
+    *,
+    download_dir: Path,
+    filename: str,
+    media_type: str,
+    content: bytes,
+) -> str:
+    if media_type == "application/pdf":
+        resource_kind = "pdf"
+    elif media_type == "text/html":
+        resource_kind = "html"
+    else:  # pragma: no cover - academic document validation owns this contract
+        raise ToolError(f"unsupported academic document media type: {media_type}")
+
+    if path.is_symlink():
+        raise ToolError("document resource cannot point to a symbolic link")
+    try:
+        resolved_download_dir = download_dir.resolve(strict=True)
+        resolved_path = path.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:  # pragma: no cover - written just above
+        raise ToolError("downloaded document is no longer available") from exc
+    if resolved_path.parent != resolved_download_dir or resolved_path.name != filename:
+        raise ToolError("document resource escaped its private download directory")
+
+    token = secrets.token_urlsafe(24)
+    while token in _DOCUMENT_RESOURCES:  # pragma: no cover - cryptographically unlikely
+        token = secrets.token_urlsafe(24)
+    _DOCUMENT_RESOURCES[token] = _DocumentResource(
+        path=resolved_path,
+        download_dir=resolved_download_dir,
+        filename=filename,
+        media_type=media_type,
+        size=len(content),
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+    return f"sigaa-document://{resource_kind}/{token}"
+
+
+def _read_document_resource(token: str, expected_media_type: str) -> bytes:
+    if _RESOURCE_TOKEN_RE.fullmatch(token) is None:
+        raise ValueError("invalid document resource identifier")
+    resource = _DOCUMENT_RESOURCES.get(token)
+    if resource is None or resource.media_type != expected_media_type:
+        raise ValueError("document resource was not found or has expired")
+
+    if resource.path.is_symlink():
+        raise ValueError("document resource is no longer a regular file")
+    try:
+        resolved = resource.path.resolve(strict=True)
+    except (FileNotFoundError, OSError) as exc:
+        raise ValueError("document resource is no longer available") from exc
+    if resolved.parent != resource.download_dir or not resolved.is_file():
+        raise ValueError("document resource escaped its private download directory")
+
+    content = resolved.read_bytes()
+    if (
+        len(content) != resource.size
+        or hashlib.sha256(content).hexdigest() != resource.sha256
+    ):
+        raise ValueError("document resource changed after it was downloaded")
+    return content
+
+
+@mcp.resource(
+    "sigaa-document://pdf/{token}",
+    name="SIGAA academic document (PDF)",
+    description="A PDF downloaded by a SIGAA academic-document tool in this server session.",
+    mime_type="application/pdf",
+)
+def _read_pdf_document_resource(token: str) -> bytes:
+    return _read_document_resource(token, "application/pdf")
+
+
+@mcp.resource(
+    "sigaa-document://html/{token}",
+    name="SIGAA enrollment certificate (HTML)",
+    description="Download-only HTML from the SIGAA enrollment-certificate tool in this server session.",
+    mime_type="application/octet-stream",
+)
+def _read_html_document_resource(token: str) -> bytes:
+    return _read_document_resource(token, "text/html")
 
 
 @mcp.tool()
 def sigaa_sync(fetch_bodies: bool = False) -> dict:
-    """Refresh from SIGAA and persist new news. The only networked tool."""
+    """Refresh the local store from SIGAA."""
     result = run_sync(Settings(), fetch_bodies=fetch_bodies)
     return {
         "ok": result.ok,

--- a/sigaa/parsers/portal.py
+++ b/sigaa/parsers/portal.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 
 from bs4 import BeautifulSoup
 
@@ -34,7 +35,8 @@ def portal_form_id(html: str) -> str:
     return form["id"]
 
 
-_MENU_FIELD_RE = re.compile(r"jsfcljs\([^,]+,\s*\{\s*'([^']+)'\s*:", re.S)
+_JSF_PARAMS_RE = re.compile(r"jsfcljs\([^,]+,\s*\{(.*?)\}\s*,", re.S)
+_JSF_PARAM_RE = re.compile(r"'([^']+)'\s*:\s*'([^']*)'")
 
 
 def find_menu_field(html: str, link_text: str) -> str | None:
@@ -43,13 +45,65 @@ def find_menu_field(html: str, link_text: str) -> str | None:
     Matches on the anchor's rendered text (handles HTML entities like ``í``).
     """
     soup = BeautifulSoup(html, "lxml")
-    target = link_text.strip().casefold()
-    for anchor in soup.select("a[onclick*='jsfcljs']"):
-        if anchor.get_text(" ", strip=True).casefold() == target:
-            match = _MENU_FIELD_RE.search(anchor["onclick"])
-            if match:
-                return match.group(1)
+    anchor = _find_menu_anchor(soup, link_text)
+    if anchor:
+        params = _jsf_params(anchor.get("onclick", ""))
+        source = next((key for key, value in params.items() if key == value), None)
+        return source or next(iter(params), None)
     return None
+
+
+def build_menu_postback(
+    html: str, link_text: str, viewstate: str | None = None
+) -> dict[str, str] | None:
+    """Build the current JSF form payload for a visible portal menu item.
+
+    Component ids and ViewState change between renders.  Mirror the browser by
+    copying the selected form's hidden inputs (including ``subsistema``) and all
+    parameters from the anchor's ``jsfcljs`` call instead of hardcoding ids.
+    """
+    soup = BeautifulSoup(html, "lxml")
+    anchor = _find_menu_anchor(soup, link_text)
+    if anchor is None:
+        return None
+    form = anchor.find_parent("form")
+    if form is None:
+        raise ValueError(f"portal menu item has no form: {link_text!r}")
+
+    form_name = form.get("name") or form.get("id")
+    if not form_name:
+        raise ValueError("portal form has no name or id")
+
+    fields: dict[str, str] = {}
+    for hidden in form.select('input[type="hidden"][name]'):
+        fields[str(hidden["name"])] = str(hidden.get("value", ""))
+    fields[str(form_name)] = str(form_name)
+    fields.update(_jsf_params(anchor.get("onclick", "")))
+    if viewstate is not None:
+        fields["javax.faces.ViewState"] = viewstate
+    if not fields.get("javax.faces.ViewState"):
+        raise ValueError("portal form has no javax.faces.ViewState")
+    return fields
+
+
+def _find_menu_anchor(soup: BeautifulSoup, link_text: str):
+    target = _normalized_label(link_text)
+    for anchor in soup.select("a[onclick*='jsfcljs']"):
+        if _normalized_label(anchor.get_text(" ", strip=True)) == target:
+            return anchor
+    return None
+
+
+def _normalized_label(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).replace("\xa0", " ")
+    return " ".join(normalized.split()).casefold()
+
+
+def _jsf_params(onclick: str) -> dict[str, str]:
+    match = _JSF_PARAMS_RE.search(onclick)
+    if not match:
+        return {}
+    return dict(_JSF_PARAM_RE.findall(match.group(1)))
 
 
 def parse_student(html: str) -> Student:

--- a/tests/fixtures/atestado_matricula.html
+++ b/tests/fixtures/atestado_matricula.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <title>Documento acadêmico de exemplo</title>
+  <link rel="stylesheet" href="/sigaa/css/atestado_matricula.css">
+</head>
+<body>
+  <img src="/sigaa/img/brasao_ufpb.png" alt="Brasão">
+  <h3>Atestado de Matr&#237;cula</h3>
+  <table id="identificacao"><tr><td>Dados fictícios</td></tr></table>
+  <table id="matriculas"><tr><td>Turma fictícia</td></tr></table>
+  <div id="autenticacao"><p>Verifique este documento no SIGAA.</p></div>
+</body>
+</html>

--- a/tests/fixtures/portal_documents.html
+++ b/tests/fixtures/portal_documents.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="pt-BR">
+<body>
+  <a href="#">Sair do SIGAA</a>
+  <form id="j_id_jsp_987654321_1" name="j_id_jsp_987654321_1" method="post">
+    <input type="hidden" name="j_id_jsp_987654321_1" value="j_id_jsp_987654321_1">
+    <input type="hidden" name="subsistema" value="12100">
+    <input type="hidden" name="portal-context" value="student">
+    <input type="hidden" name="javax.faces.ViewState" value="fresh-view-state">
+
+    <a href="#" onclick="jsfcljs(document.getElementById('j_id_jsp_987654321_1'), {'j_id_jsp_987654321_1:history':'j_id_jsp_987654321_1:history'}, ''); return false">
+      <span>Histórico</span><br><span>acadêmico</span>
+    </a>
+    <a href="#" onclick="
+      jsfcljs(
+        document.getElementById('j_id_jsp_987654321_1'),
+        { 'j_id_jsp_987654321_1:declaration' : 'j_id_jsp_987654321_1:declaration', 'origin' : 'portal' },
+        ''
+      ); return false">
+      Declaração de vínculo
+    </a>
+    <a href="#" onclick="jsfcljs(document.getElementById('j_id_jsp_987654321_1'), {'j_id_jsp_987654321_1:certificate':'j_id_jsp_987654321_1:certificate'}, ''); return false">
+      Atestado&nbsp;de matrícula
+    </a>
+  </form>
+</body>
+</html>

--- a/tests/test_academic_documents.py
+++ b/tests/test_academic_documents.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import os
+import stat
+import unicodedata
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import urljoin
+
+import httpx
+import pytest
+from bs4 import BeautifulSoup
+
+from sigaa import cli as cli_module
+from sigaa.client import SigaaClient
+from sigaa.documents import (
+    ATESTADO_MATRICULA,
+    DECLARACAO_VINCULO,
+    HISTORICO,
+    AcademicDocumentError,
+    validate_academic_document,
+    write_academic_document,
+)
+from sigaa.http import AuthError, Session
+from sigaa.parsers import portal as portal_parser
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PORTAL = (FIXTURES / "portal_documents.html").read_text(encoding="utf-8")
+ATESTADO = (FIXTURES / "atestado_matricula.html").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("label", "source"),
+    [
+        ("Histórico acadêmico", "j_id_jsp_987654321_1:history"),
+        ("Declaração de vínculo", "j_id_jsp_987654321_1:declaration"),
+        ("Atestado de matrícula", "j_id_jsp_987654321_1:certificate"),
+    ],
+)
+def test_build_document_postback_copies_current_form_fields(label, source):
+    fields = portal_parser.build_menu_postback(PORTAL, label)
+
+    assert fields is not None
+    assert fields["j_id_jsp_987654321_1"] == "j_id_jsp_987654321_1"
+    assert fields["subsistema"] == "12100"
+    assert fields["portal-context"] == "student"
+    assert fields["javax.faces.ViewState"] == "fresh-view-state"
+    assert fields[source] == source
+
+
+def test_build_document_postback_copies_all_jsf_params_and_normalizes_label():
+    decomposed = unicodedata.normalize("NFD", "DECLARAÇÃO DE VÍNCULO")
+    fields = portal_parser.build_menu_postback(PORTAL, decomposed)
+
+    assert fields is not None
+    assert fields["origin"] == "portal"
+
+
+def test_build_document_postback_requires_viewstate():
+    html = PORTAL.replace(
+        '<input type="hidden" name="javax.faces.ViewState" value="fresh-view-state">',
+        "",
+    )
+    with pytest.raises(ValueError, match="ViewState"):
+        portal_parser.build_menu_postback(html, "Histórico acadêmico")
+
+
+@pytest.mark.parametrize("kind", [HISTORICO, DECLARACAO_VINCULO])
+def test_validate_pdf_document(kind):
+    content = b"%PDF-1.7\nsynthetic fixture"
+    document = validate_academic_document(
+        kind,
+        content,
+        "application/pdf",
+        "attachment; filename=../../documento.pdf",
+    )
+
+    assert document.content == content
+    assert document.media_type == "application/pdf"
+    assert document.filename == "documento.pdf"
+
+
+@pytest.mark.parametrize(
+    ("content", "content_type"),
+    [
+        (b"<html>login</html>", "text/html;charset=ISO-8859-1"),
+        (b"not a PDF", "application/pdf"),
+        (b"%PDF-1.7", "text/html"),
+    ],
+)
+def test_validate_pdf_rejects_http_200_error_pages(content, content_type):
+    with pytest.raises(AcademicDocumentError, match="valid PDF"):
+        validate_academic_document(HISTORICO, content, content_type)
+
+
+def test_validate_atestado_preserves_encoding_and_adds_asset_base():
+    content = ATESTADO.encode("iso-8859-1")
+    document = validate_academic_document(
+        ATESTADO_MATRICULA,
+        content,
+        "text/html;charset=ISO-8859-1",
+    )
+
+    assert document.content != content
+    assert b'<base href="https://sigaa.ufpb.br/">' in document.content
+    assert document.media_type == "text/html"
+    assert document.charset == "iso-8859-1"
+    assert document.filename == "atestado-matricula.html"
+
+    saved = BeautifulSoup(document.content.decode("iso-8859-1"), "lxml")
+    assert urljoin(saved.base["href"], saved.link["href"]) == (
+        "https://sigaa.ufpb.br/sigaa/css/atestado_matricula.css"
+    )
+
+
+def test_validate_atestado_rejects_unexpected_html():
+    with pytest.raises(AcademicDocumentError, match="unexpected"):
+        validate_academic_document(
+            ATESTADO_MATRICULA,
+            b"<html><h3>Portal</h3></html>",
+            "text/html;charset=ISO-8859-1",
+        )
+
+
+class _DocumentSession:
+    def __init__(self, responses, fresh_portal=PORTAL):
+        self.responses = iter(responses)
+        self.fresh_portal = fresh_portal
+        self.posts = []
+        self.login_count = 0
+
+    def post_download(self, url, data, *, retry_on_auth=True):
+        self.posts.append((url, data.copy(), retry_on_auth))
+        result = next(self.responses)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def login(self):
+        self.login_count += 1
+        return self.fresh_portal
+
+
+def _client_with(session, portal=PORTAL):
+    client = object.__new__(SigaaClient)
+    client._session = session
+    client._portal_html = portal
+    return client
+
+
+def test_client_downloads_each_document_with_its_dynamic_source_field():
+    pdf = (b"%PDF-1.7\nfixture", "application/pdf", None)
+    session = _DocumentSession([pdf, pdf])
+    client = _client_with(session)
+
+    assert client.get_historico_pdf().startswith(b"%PDF-")
+    assert client.get_declaracao_vinculo_pdf().startswith(b"%PDF-")
+
+    first_fields = session.posts[0][1]
+    second_fields = session.posts[1][1]
+    assert "j_id_jsp_987654321_1:history" in first_fields
+    assert "j_id_jsp_987654321_1:declaration" in second_fields
+    assert all(retry is False for _, _, retry in session.posts)
+
+
+def test_client_rebuilds_postback_after_session_expiry():
+    stale = PORTAL.replace("987654321", "111111111").replace(
+        "fresh-view-state", "stale-view-state"
+    )
+    pdf = (b"%PDF-1.7\nfresh", "application/pdf", None)
+    session = _DocumentSession([AuthError("expired"), pdf], fresh_portal=PORTAL)
+    client = _client_with(session, portal=stale)
+
+    document = client.download_academic_document(HISTORICO)
+
+    assert document.content == pdf[0]
+    assert session.login_count == 1
+    assert session.posts[0][1]["javax.faces.ViewState"] == "stale-view-state"
+    assert session.posts[1][1]["javax.faces.ViewState"] == "fresh-view-state"
+    assert "j_id_jsp_111111111_1:history" in session.posts[0][1]
+    assert "j_id_jsp_987654321_1:history" in session.posts[1][1]
+
+
+def test_session_can_delegate_auth_retry_to_jsf_operation():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/html;charset=UTF-8"},
+            text='<html><a href="/sigaa/logon.jsf">Entrar</a></html>',
+        )
+
+    transport = httpx.MockTransport(handler)
+    raw_client = httpx.Client(transport=transport)
+    session = Session("example", "not-a-real-password", client=raw_client)
+    session._authenticated = True
+    try:
+        with pytest.raises(AuthError, match="expired"):
+            session.post_download("https://sigaa.invalid/report", {}, retry_on_auth=False)
+    finally:
+        session.close()
+
+
+def test_write_document_refuses_overwrite_unless_explicit(tmp_path):
+    first = validate_academic_document(
+        HISTORICO, b"%PDF-1.7\nfirst", "application/pdf"
+    )
+    second = validate_academic_document(
+        HISTORICO, b"%PDF-1.7\nsecond", "application/pdf"
+    )
+    target = tmp_path / "historico.pdf"
+
+    assert write_academic_document(first, target) == target.resolve()
+    if os.name != "nt":
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    with pytest.raises(FileExistsError):
+        write_academic_document(second, target)
+    assert target.read_bytes() == first.content
+
+    write_academic_document(second, target, overwrite=True)
+    assert target.read_bytes() == second.content
+    if os.name != "nt":
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize(
+    ("command", "default_output", "kind"),
+    [
+        ("historico", "historico.pdf", None),
+        ("declaracao-vinculo", "declaracao-vinculo.pdf", DECLARACAO_VINCULO),
+        ("atestado-matricula", "atestado-matricula.html", ATESTADO_MATRICULA),
+    ],
+)
+def test_cli_exposes_all_academic_document_commands(command, default_output, kind):
+    args = cli_module._build_parser().parse_args([command])
+
+    assert args.out == default_output
+    assert args.force is False
+    if kind is not None:
+        assert args.document_kind == kind
+
+
+def test_cli_download_writes_only_validated_document(monkeypatch, tmp_path, capsys):
+    document = validate_academic_document(
+        DECLARACAO_VINCULO,
+        b"%PDF-1.7\nprivate document bytes",
+        "application/pdf",
+    )
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def download_academic_document(self, kind):
+            assert kind == DECLARACAO_VINCULO
+            return document
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    target = tmp_path / "declaracao.pdf"
+    args = SimpleNamespace(
+        out=str(target), force=False, document_kind=DECLARACAO_VINCULO
+    )
+    monkeypatch.setattr(cli_module, "SigaaClient", FakeClient)
+
+    assert cli_module._cmd_academic_document(args, settings) == 0
+    assert target.read_bytes() == document.content
+    stdout = capsys.readouterr().out
+    assert "application/pdf" in stdout
+    assert "private document bytes" not in stdout
+
+
+def test_cli_existing_output_short_circuits_before_credentials(tmp_path, capsys):
+    target = tmp_path / "historico.pdf"
+    target.write_bytes(b"keep me")
+
+    class SettingsThatMustNotResolve:
+        username = "configured-user"
+
+        def resolve_password(self):
+            raise AssertionError("credentials should not be resolved")
+
+    args = SimpleNamespace(out=str(target), force=False, document_kind=HISTORICO)
+    result = cli_module._cmd_academic_document(args, SettingsThatMustNotResolve())
+
+    assert result == 1
+    assert target.read_bytes() == b"keep me"
+    assert "--force" in capsys.readouterr().err
+
+
+def test_cli_invalid_response_does_not_create_output(monkeypatch, tmp_path, capsys):
+    class FakeClient:
+        def __init__(self, username, password):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def download_academic_document(self, kind):
+            raise AcademicDocumentError("SIGAA did not return a valid PDF")
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    target = tmp_path / "historico.pdf"
+    args = SimpleNamespace(out=str(target), force=False, document_kind=HISTORICO)
+    monkeypatch.setattr(cli_module, "SigaaClient", FakeClient)
+
+    assert cli_module._cmd_academic_document(args, settings) == 1
+    assert not target.exists()
+    assert "download failed" in capsys.readouterr().err

--- a/tests/test_academic_documents.py
+++ b/tests/test_academic_documents.py
@@ -72,12 +72,10 @@ def test_validate_pdf_document(kind):
         kind,
         content,
         "application/pdf",
-        "attachment; filename=../../documento.pdf",
     )
 
     assert document.content == content
     assert document.media_type == "application/pdf"
-    assert document.filename == "documento.pdf"
 
 
 @pytest.mark.parametrize(
@@ -105,7 +103,6 @@ def test_validate_atestado_preserves_encoding_and_adds_asset_base():
     assert b'<base href="https://sigaa.ufpb.br/">' in document.content
     assert document.media_type == "text/html"
     assert document.charset == "iso-8859-1"
-    assert document.filename == "atestado-matricula.html"
 
     saved = BeautifulSoup(document.content.decode("iso-8859-1"), "lxml")
     assert urljoin(saved.base["href"], saved.link["href"]) == (
@@ -181,6 +178,19 @@ def test_client_rebuilds_postback_after_session_expiry():
     assert "j_id_jsp_987654321_1:history" in session.posts[1][1]
 
 
+def test_client_surfaces_error_after_one_session_refresh():
+    session = _DocumentSession(
+        [AuthError("expired"), AcademicDocumentError("invalid document")]
+    )
+    client = _client_with(session)
+
+    with pytest.raises(AcademicDocumentError, match="invalid document"):
+        client.download_academic_document(HISTORICO)
+
+    assert session.login_count == 1
+    assert len(session.posts) == 2
+
+
 def test_session_can_delegate_auth_retry_to_jsf_operation():
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -225,7 +235,7 @@ def test_write_document_refuses_overwrite_unless_explicit(tmp_path):
 @pytest.mark.parametrize(
     ("command", "default_output", "kind"),
     [
-        ("historico", "historico.pdf", None),
+        ("historico", "historico.pdf", HISTORICO),
         ("declaracao-vinculo", "declaracao-vinculo.pdf", DECLARACAO_VINCULO),
         ("atestado-matricula", "atestado-matricula.html", ATESTADO_MATRICULA),
     ],
@@ -235,8 +245,7 @@ def test_cli_exposes_all_academic_document_commands(command, default_output, kin
 
     assert args.out == default_output
     assert args.force is False
-    if kind is not None:
-        assert args.document_kind == kind
+    assert args.document_kind == kind
 
 
 def test_cli_download_writes_only_validated_document(monkeypatch, tmp_path, capsys):

--- a/tests/test_mcp_document_resources.py
+++ b/tests/test_mcp_document_resources.py
@@ -49,7 +49,6 @@ def test_document_tool_returns_readable_resource_link(
 ):
     document = AcademicDocument(
         kind=kind,
-        filename=filename,
         media_type=media_type,
         content=content,
     )

--- a/tests/test_mcp_document_resources.py
+++ b/tests/test_mcp_document_resources.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.shared.memory import create_connected_server_and_client_session
+from mcp.types import BlobResourceContents, ResourceLink
+
+from sigaa import mcp_server
+from sigaa.documents import (
+    ATESTADO_MATRICULA,
+    DECLARACAO_VINCULO,
+    AcademicDocument,
+)
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "kind", "filename", "media_type", "content"),
+    [
+        (
+            "sigaa_download_declaracao_vinculo",
+            DECLARACAO_VINCULO,
+            "declaracao.pdf",
+            "application/pdf",
+            b"%PDF-1.7\nsynthetic MCP resource bytes",
+        ),
+        (
+            "sigaa_download_atestado_matricula",
+            ATESTADO_MATRICULA,
+            "atestado.html",
+            "text/html",
+            b"<!doctype html><html><body>synthetic certificate</body></html>",
+        ),
+    ],
+)
+def test_document_tool_returns_readable_resource_link(
+    monkeypatch,
+    tmp_path,
+    tool_name,
+    kind,
+    filename,
+    media_type,
+    content,
+):
+    document = AcademicDocument(
+        kind=kind,
+        filename=filename,
+        media_type=media_type,
+        content=content,
+    )
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def download_academic_document(self, requested_kind):
+            assert requested_kind == kind
+            return document
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+
+    async def exercise_resource():
+        async with create_connected_server_and_client_session(mcp_server.mcp) as session:
+            await session.initialize()
+            result = await session.call_tool(
+                tool_name,
+                {"filename": filename},
+            )
+            links = [item for item in result.content if isinstance(item, ResourceLink)]
+            resource = await session.read_resource(links[0].uri) if len(links) == 1 else None
+            return result, links, resource
+
+    result, links, resource = asyncio.run(exercise_resource())
+
+    assert result.isError is False
+    assert result.structuredContent is not None
+    assert result.structuredContent["kind"] == kind
+    assert result.structuredContent["filename"] == filename
+    assert result.structuredContent["mime_type"] == media_type
+    assert result.structuredContent["size"] == len(content)
+    expected_resource_media_type = (
+        "application/octet-stream" if media_type == "text/html" else media_type
+    )
+    assert (
+        result.structuredContent["resource_mime_type"]
+        == expected_resource_media_type
+    )
+
+    assert len(links) == 1
+    link = links[0]
+    assert link.name == filename
+    assert link.mimeType == expected_resource_media_type
+    assert link.size == len(content)
+    assert link.uri.scheme != "file"
+    assert filename not in str(link.uri)
+    assert str(tmp_path) not in str(link.uri)
+    assert content not in repr(result).encode()
+
+    assert resource is not None
+    assert len(resource.contents) == 1
+    [resource_content] = resource.contents
+    assert isinstance(resource_content, BlobResourceContents)
+    assert resource_content.uri == link.uri
+    assert resource_content.mimeType == expected_resource_media_type
+    assert base64.b64decode(resource_content.blob, validate=True) == content

--- a/tests/test_mcp_documents.py
+++ b/tests/test_mcp_documents.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import ResourceLink
+
+from sigaa import mcp_server
+from sigaa.documents import DECLARACAO_VINCULO, validate_academic_document
+
+
+def test_mcp_registers_all_academic_document_tools():
+    names = set(mcp_server.mcp._tool_manager._tools)
+    assert {
+        "sigaa_download_historico",
+        "sigaa_download_declaracao_vinculo",
+        "sigaa_download_atestado_matricula",
+    } <= names
+
+
+def test_mcp_document_download_returns_metadata_not_content(monkeypatch, tmp_path):
+    document = validate_academic_document(
+        DECLARACAO_VINCULO,
+        b"%PDF-1.7\nprivate MCP bytes",
+        "application/pdf",
+    )
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def download_academic_document(self, kind):
+            assert kind == DECLARACAO_VINCULO
+            return document
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+    target = tmp_path / "declaracao.pdf"
+
+    result = mcp_server._download_academic_document(DECLARACAO_VINCULO, target.name)
+
+    assert target.read_bytes() == document.content
+    metadata = result.structuredContent
+    assert metadata is not None
+    assert metadata == {
+        "kind": DECLARACAO_VINCULO,
+        "filename": target.name,
+        "mime_type": "application/pdf",
+        "size": len(document.content),
+        "resource_uri": metadata["resource_uri"],
+        "resource_mime_type": "application/pdf",
+    }
+    [link] = [item for item in result.content if isinstance(item, ResourceLink)]
+    assert str(link.uri) == metadata["resource_uri"]
+    assert b"private MCP bytes" not in repr(result).encode()
+
+
+def test_document_resource_rejects_unknown_and_changed_files(tmp_path):
+    content = b"original private bytes"
+    target = tmp_path / "documento.pdf"
+    target.write_bytes(content)
+
+    uri = mcp_server._register_document_resource(
+        target.resolve(),
+        download_dir=tmp_path.resolve(),
+        filename=target.name,
+        media_type="application/pdf",
+        content=content,
+    )
+    token = uri.rsplit("/", 1)[-1]
+
+    assert mcp_server._read_document_resource(token, "application/pdf") == content
+    with pytest.raises(ValueError, match="invalid document resource identifier"):
+        mcp_server._read_document_resource("not-a-real-token", "application/pdf")
+    with pytest.raises(ValueError, match="not found or has expired"):
+        mcp_server._read_document_resource("A" * 32, "application/pdf")
+
+    target.write_bytes(b"changed private bytes!")
+    with pytest.raises(ValueError, match="changed after it was downloaded"):
+        mcp_server._read_document_resource(token, "application/pdf")
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "A" * 31,
+        "A" * 33,
+        "A" * 31 + "%",
+        "A" * 31 + "\\",
+        "A" * 31 + "?",
+        "A" * 31 + "#",
+        "A" * 30 + "%2F",
+    ],
+)
+def test_mcp_rejects_malformed_document_resource_tokens(token):
+    with pytest.raises(ValueError, match="invalid document resource identifier"):
+        mcp_server._read_document_resource(token, "application/pdf")
+
+
+def test_mcp_existing_output_short_circuits_before_credentials(monkeypatch, tmp_path):
+    target = tmp_path / "documento.pdf"
+    target.write_bytes(b"keep me")
+
+    def settings_must_not_be_built():
+        raise AssertionError("credentials should not be resolved")
+
+    monkeypatch.setattr(mcp_server, "Settings", settings_must_not_be_built)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+    with pytest.raises(ToolError, match="already exists"):
+        mcp_server._download_academic_document(DECLARACAO_VINCULO, target.name)
+
+    assert target.read_bytes() == b"keep me"
+
+
+@pytest.mark.parametrize(
+    "filename", ["../outside.pdf", "subdir/document.pdf", "C:\\outside.pdf", "CON"]
+)
+def test_mcp_rejects_paths_and_unsafe_filenames(filename):
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server._download_academic_document(DECLARACAO_VINCULO, filename)

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
+    async def exercise_server():
+        environment = dict(os.environ)
+        environment.pop("SIGAA_USER", None)
+        environment.pop("SIGAA_PASS", None)
+        environment["SIGAA_DOWNLOAD_DIR"] = str(tmp_path)
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "sigaa.mcp_server"],
+            env=environment,
+        )
+
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                document_tools = {
+                    tool.name: tool
+                    for tool in listed.tools
+                    if tool.name
+                    in {
+                        "sigaa_download_historico",
+                        "sigaa_download_declaracao_vinculo",
+                        "sigaa_download_atestado_matricula",
+                    }
+                }
+                assert len(document_tools) == 3
+                for tool in document_tools.values():
+                    assert set(tool.inputSchema.get("properties", {})) == {"filename"}
+
+                rejected = await session.call_tool(
+                    "sigaa_download_historico", {"filename": "../outside.pdf"}
+                )
+                assert rejected.isError is True
+                assert "safe file name" in " ".join(
+                    getattr(item, "text", "") for item in rejected.content
+                )
+
+    asyncio.run(exercise_server())
+    assert not (tmp_path.parent / "outside.pdf").exists()


### PR DESCRIPTION
## Summary

- add validated downloads for the academic transcript, enrollment declaration, and enrollment certificate
- expose the three documents through CLI commands with explicit overwrite protection
- expose MCP tools that return structured metadata plus opaque `ResourceLink` attachments
- rebuild render-scoped JSF postbacks after session refreshes instead of replaying stale component ids
- document the networked behavior, private download directory, and MCP resource lifecycle

## Safety and developer impact

- validate PDF signatures/content types and the expected enrollment-certificate HTML structure before writing
- confine MCP output to a private configurable directory, reject arbitrary paths and existing targets, and verify resource size/hash before reads
- serve the active certificate HTML as a download-only binary MCP resource
- keep credentials, cookies, local MCP configuration, downloaded documents, and absolute filesystem paths out of the public tool result and fixtures
- require `mcp>=1.27,<2` for direct `CallToolResult`/`ResourceLink` support
- remove the legacy license classifier that conflicts with the SPDX license field under current setuptools wheel builds

## Validation

- `python -m pytest tests/test_academic_documents.py tests/test_mcp_documents.py tests/test_mcp_document_resources.py tests/test_mcp_protocol.py -q` — 41 passed
- `python -m pytest -q --deselect tests/test_setup_wizard.py::test_resolve_script_falls_back_to_current_python_dir` — 102 passed, 1 deselected
- `python -m compileall -q sigaa tests`
- `git diff --check`
- isolated wheel build

## Known pre-existing issue

The complete suite still has one Windows-only failure in `test_resolve_script_falls_back_to_current_python_dir`: the test supplies a POSIX executable path but Windows path resolution produces a drive-qualified `.exe` path. The failing test and implementation are outside this diff.
