### PR TITLE
Add CRA and curriculum progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ User-friendly client for **SIGAA UFPB** (sigaa.ufpb.br) built for automation:
 a **CLI** and an **MCP server** over a layered Python core. Scope: single user.
 
 SIGAA has no official API. This wraps the JSF web flow: login (cookie jar +
-`ViewState`, no JWT, no CAPTCHA), enrolled classes, and **per-class news
-channels** persisted to SQLite with stable dedup by news id.
+`ViewState`, no JWT, no CAPTCHA), enrolled classes, academic progress and CRA,
+plus **per-class news channels** persisted to SQLite with stable dedup by news
+id.
 
 ## Install
 
@@ -53,6 +54,8 @@ sigaa news --unread --mark-seen
 sigaa grades --semester 2025.1 # grades report by semester
 sigaa deadlines            # assessment/task due dates
 sigaa ics --out sigaa.ics  # export classes + deadlines as a calendar
+sigaa curriculum           # live CRA, enrolled + required pending components
+sigaa cra --json           # official CRA as JSON from the academic transcript
 sigaa historico --out h.pdf # download the academic transcript PDF (networked)
 sigaa declaracao-vinculo --out declaracao-vinculo.pdf # enrollment declaration PDF (networked)
 sigaa atestado-matricula --out atestado-matricula.html # enrollment certificate HTML (networked)
@@ -69,10 +72,20 @@ server without manual absolute-path editing.
 
 Tools: `sigaa_list_classes`, `sigaa_list_news`, `sigaa_get_news_body`,
 `sigaa_get_schedule`, `sigaa_list_grades`, `sigaa_list_deadlines`,
-`sigaa_export_ics`, `sigaa_download_historico`,
+`sigaa_get_curriculum`, `sigaa_get_cra`, `sigaa_export_ics`,
+`sigaa_download_historico`,
 `sigaa_download_declaracao_vinculo`, `sigaa_download_atestado_matricula`,
 `sigaa_sync`. Store-backed reads are offline; sync, live lookups, and downloads
 touch the network.
+
+`sigaa_get_curriculum` is networked and uses the same normalized contract and
+filters as `sigaa curriculum`: `status`, `required_only`, `period`,
+`include_requirements`, and `include_cra`. Its default `current` view contains
+enrolled components plus required pending ones. Pending optional components are
+choices toward the remaining optional workload, not courses that must all be
+completed. `sigaa_get_cra` is also networked and reads the official CRA from the
+academic transcript; a new student may receive `source: "unavailable"` until
+SIGAA reports one. Neither response exposes SIGAA's internal student id.
 
 Document tools accept a safe filename (not an arbitrary path), never overwrite,
 and write under the app's private `downloads` directory. Set
@@ -154,17 +167,18 @@ sigaa/
   http.py       session: cookie jar, ViewState, re-login + retry
   auth.py       login flow
   client.py     SigaaClient -> domain models
-  models.py     Student, Turma, NewsItem, Schedule
-  parsers/      portal, news, schedule (HTML isolated here)
+  models.py     Student, Turma, NewsItem, Schedule, CurriculumStatus
+  parsers/      portal, news, schedule, curriculum, transcript
   store/        SQLite db + repository (dedup, queries)
   services/     sync (fetch -> diff -> persist)
   cli.py        command line
   mcp_server.py agent tools
 ```
 
-Adding a feature (materials, attendance) = a parser + client method + store
-columns + a CLI/MCP surface. HTML changes touch only `parsers/`. Implemented so
-far: classes, news (+bodies), grades, deadlines, ICS export.
+Adding a feature (materials, attendance) = a parser + client method and a
+CLI/MCP surface, plus store columns when it is persisted. HTML changes touch
+only `parsers/`. Implemented so far: classes, news (+bodies), grades, deadlines,
+curriculum progress, official CRA, academic documents, and ICS export.
 
 `exporters/` turns store data into interchange formats (currently `ics`).
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -15,10 +15,10 @@ sigaa [--user USUARIO] [--db CAMINHO] <comando> [opções]
 | `--db` | sobrescreve o caminho do SQLite (senão usa `SIGAA_DB` ou o padrão) |
 
 <Note>
-`login`, `sync`, `watch`, `historico`, `declaracao-vinculo`,
-`atestado-matricula`, `attendance`, `plan` e o download de materiais acessam a
-**rede**. Os demais comandos leem do **banco local**. Quase todo comando de leitura
-aceita `--json`.
+`login`, `sync`, `watch`, `curriculum`, `cra`, `historico`,
+`declaracao-vinculo`, `atestado-matricula`, `attendance`, `plan` e o download
+de materiais acessam a **rede**. Os demais comandos leem do **banco local**.
+Quase todo comando de leitura aceita `--json`.
 </Note>
 
 ## Setup
@@ -79,6 +79,49 @@ imprimir; o arquivo carrega o estilo e as imagens oficiais do SIGAA pela rede.
 |---|---|
 | `--out ARQ` | arquivo de saída (padrão `atestado-matricula.html`) |
 | `--force` | substitui o arquivo de saída se ele já existir |
+
+### `curriculum`
+
+Mostra ao vivo o progresso da integralização curricular, o CRA, os componentes
+matriculados e os que ainda faltam. **Networked.**
+
+```bash
+sigaa curriculum
+sigaa curriculum --status pending --requirements
+sigaa curriculum --status completed --period 3 --json
+```
+
+A visão padrão, `--status current`, reúne os componentes **matriculados** e os
+**pendentes obrigatórios**. Componentes optativos pendentes são alternativas
+para cumprir a carga horária optativa; não significa que todos sejam
+obrigatórios. Use `--status pending` para inspecionar também essas opções.
+
+| Flag | Descrição |
+|---|---|
+| `--status {current,enrolled,pending,completed,all}` | escolhe os componentes retornados (padrão: `current`) |
+| `--required-only` | oculta componentes optativos |
+| `--period N` | filtra pelo período da estrutura curricular |
+| `--requirements` | inclui as expressões de pré-requisito e correquisito |
+| `--no-cra` | evita a requisição adicional do histórico acadêmico |
+| `--json` | usa o contrato JSON normalizado, também exposto pelo MCP |
+
+O contrato normalizado não expõe o identificador interno `idDiscente` do SIGAA.
+
+### `cra`
+
+Mostra o CRA oficial extraído do histórico acadêmico. **Networked.**
+
+```bash
+sigaa cra
+sigaa cra --json
+```
+
+| Flag | Descrição |
+|---|---|
+| `--json` | retorna `value` e `source` em JSON |
+
+Para um ingressante cujo histórico ainda não informa CRA, o comando retorna o
+estado válido `unavailable` em vez de tratar a ausência como erro.
 
 ## Ler do banco
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -85,6 +85,28 @@ sigaa grades                 # notas por semestre
 sigaa deadlines              # prazos
 ```
 
+## 5. Ver CRA e currículo ao vivo
+
+Essas consultas acessam o SIGAA pela rede e não dependem de um `sync` anterior:
+
+```bash
+sigaa curriculum             # matriculados + pendentes obrigatórios
+sigaa curriculum --status pending --requirements
+sigaa cra --json             # CRA oficial extraído do histórico
+```
+
+Na visão padrão do currículo, optativas pendentes ficam de fora porque são
+**opções** para completar a carga horária optativa, não componentes que você
+precisa cursar todos. Use `--status pending` para vê-las. Para ingressantes, o
+histórico pode ainda não informar um CRA; nesse caso, `sigaa cra` retorna
+`unavailable`.
+
+As mesmas consultas estão disponíveis no MCP como `sigaa_get_curriculum` e
+`sigaa_get_cra`. Ambas acessam a rede. A primeira aceita `status` com os valores
+`current`, `enrolled`, `pending`, `completed` e `all`, além dos filtros
+equivalentes `required_only`, `period`, `include_requirements` e `include_cra`.
+Sua resposta segue o mesmo contrato JSON do CLI e não expõe `idDiscente`.
+
 <Tip>
 Rode `sigaa sync` de tempos em tempos (ou deixe `sigaa watch` rodando) pra manter o
 banco atualizado. Veja todos os comandos na [Referência do CLI](/cli).

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,10 +3,12 @@ title: "Introdução"
 description: "O que é o sigaa-ai-agent e como ele funciona."
 ---
 
-O **sigaa-ai-agent** é um cliente do **SIGAA UFPB** feito para automação: um **CLI**
-sobre um núcleo Python em camadas. Como o SIGAA não tem API oficial, ele entra pelo
-fluxo web (login com cookie + `ViewState`) e busca suas **turmas, notícias, notas,
-faltas, prazos, plano de curso e materiais** — guardando tudo num **SQLite local**.
+O **sigaa-ai-agent** é um cliente do **SIGAA UFPB** feito para automação: um
+**CLI** e um **servidor MCP** sobre um núcleo Python em camadas. Como o SIGAA não
+tem API oficial, ele entra pelo fluxo web (login com cookie + `ViewState`) e
+busca suas **turmas, notícias, notas, faltas, prazos, plano de curso, materiais,
+CRA e integralização curricular**. Os dados sincronizados ficam num **SQLite
+local**; CRA e currículo são consultas ao vivo.
 
 <Note>
 As listagens armazenadas no SQLite são rápidas e funcionam offline. Login,
@@ -28,6 +30,8 @@ sync/watch, consultas ao vivo e downloads acessam o SIGAA pela rede.
 
 - Listar turmas e o **horário** decodificado da semana
 - Ver **notícias**, **notas** (gerais e por turma), **prazos** e **frequência**
+- Ver o **CRA oficial**, os componentes matriculados e o que falta para integralizar
+  o currículo
 - Baixar **materiais** das turmas
 - Baixar o **histórico** e a **declaração de vínculo** em PDF
 - Baixar o **atestado de matrícula** como HTML imprimível, com assets oficiais do SIGAA

--- a/docs/sigaa-exploration.md
+++ b/docs/sigaa-exploration.md
@@ -45,7 +45,8 @@ posts off the same cached `turma_html` without re-entering.
 | Meus Dados Pessoais | ⚪ | Profile fields. |
 | Declaração de Vínculo | ✅ | Enrollment declaration as PDF (`sigaa declaracao-vinculo` / `sigaa_download_declaracao_vinculo`). |
 | Ver Comprovante de Matrícula | ⚪ | Enrollment receipt. |
-| Consultar Estrutura Curricular | ⚪ | Curriculum + pending CH (progress already on portal header). |
+| Consultar Estrutura Curricular | ✅ | Progresso e componentes ao vivo via `get_curriculum_status`, `sigaa curriculum` e `sigaa_get_curriculum`. A visão padrão reúne matriculados + pendentes obrigatórios; optativas pendentes são opções, não componentes todos obrigatórios. |
+| CRA | ✅ | Valor oficial extraído do histórico acadêmico via `get_cra`, `sigaa cra` e `sigaa_get_cra`; pode estar indisponível para um ingressante cujo histórico ainda não o informe. |
 
 ## Confirmed working endpoints (reference)
 
@@ -53,6 +54,11 @@ posts off the same cached `turma_html` without re-entering.
 - Enter turma: `POST /sigaa/portais/discente/beta/discente.jsf` with `{form_id, field, idTurma, ViewState=j_id1}`.
 - TV menu / news body: `POST /sigaa/ava/index.jsf` with `formMenu` or per-row form fields, `ViewState=j_id2`.
 - Grades report: portal sidebar postback "Minhas Notas" → `tabelaRelatorio` per semester.
+- Currículo: `GET /sigaa/portal/discente/integralizacao/` (entrada/redirecionamento) e depois `GET /sigaa/portal/discente/integralizacao/dados/` para o JSON.
+- CRA: baixa o histórico acadêmico pelo postback JSF do portal e extrai localmente o valor oficial do PDF.
+
+A resposta normalizada de currículo do CLI/MCP omite deliberadamente o
+identificador interno do estudante no SIGAA (`idDiscente`).
 
 ## Recommended next order
 1. ~~Histórico acadêmico~~ — ✅ done (PDF download).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "beautifulsoup4>=4.12",
     "lxml>=5.0",
     "keyring>=24",
+    "pypdf>=5.0,<7",
 ]
 
 [project.urls]

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -8,9 +8,12 @@ import sys
 import time
 from pathlib import Path
 
+import httpx
+
 from . import setup_wizard
 from .client import SigaaClient
 from .config import Settings
+from .curriculum import COMPONENT_VIEWS, curriculum_to_dict
 from .documents import (
     ATESTADO_MATRICULA,
     DECLARACAO_VINCULO,
@@ -20,7 +23,9 @@ from .documents import (
 )
 from .exporters.ics import build_calendar
 from .http import AuthError
+from .parsers.curriculum import CurriculumDataError
 from .parsers.schedule import day_name, decode_schedule
+from .parsers.transcript import CraUnavailableError, TranscriptParseError
 from .services import whatsnew
 from .services.sync import sync
 from .store.db import connect
@@ -72,6 +77,39 @@ def _build_parser() -> argparse.ArgumentParser:
     p_grades.add_argument("--class", dest="klass", help="show one class's per-turma grade breakdown")
     p_grades.add_argument("--json", action="store_true")
     p_grades.set_defaults(func=_cmd_grades)
+
+    p_curriculum = sub.add_parser(
+        "curriculum",
+        help="live CRA, curriculum progress, enrolled and pending components",
+    )
+    p_curriculum.add_argument(
+        "--status",
+        choices=COMPONENT_VIEWS,
+        default="current",
+        help="components to return (default: enrolled + required pending)",
+    )
+    p_curriculum.add_argument(
+        "--required-only",
+        action="store_true",
+        help="hide optional components",
+    )
+    p_curriculum.add_argument("--period", type=int, help="filter by curriculum period")
+    p_curriculum.add_argument(
+        "--requirements",
+        action="store_true",
+        help="include prerequisite and corequisite expressions",
+    )
+    p_curriculum.add_argument(
+        "--no-cra",
+        action="store_true",
+        help="skip the academic-transcript request",
+    )
+    p_curriculum.add_argument("--json", action="store_true")
+    p_curriculum.set_defaults(func=_cmd_curriculum)
+
+    p_cra = sub.add_parser("cra", help="show the official CRA from the transcript")
+    p_cra.add_argument("--json", action="store_true")
+    p_cra.set_defaults(func=_cmd_cra)
 
     p_dl = sub.add_parser("deadlines", help="list assessment/task deadlines from the store")
     p_dl.add_argument("--class", dest="klass", help="filter by class code")
@@ -240,6 +278,73 @@ def _cmd_grades(args, settings: Settings) -> int:
         units = " ".join(g.units) if g.units else "—"
         result = g.result or "—"
         print(f"  {g.code:12} {g.discipline[:40]:40} {units:20} = {result:5} {g.status or ''}")
+    return 0
+
+
+def _cmd_curriculum(args, settings: Settings) -> int:
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        print("missing credentials (set SIGAA_USER and keyring/SIGAA_PASS)", file=sys.stderr)
+        return 1
+
+    try:
+        with SigaaClient(settings.username, password) as client:
+            curriculum = client.get_curriculum_status(include_cra=not args.no_cra)
+    except (
+        AcademicDocumentError,
+        AuthError,
+        CurriculumDataError,
+        TranscriptParseError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        print(f"curriculum lookup failed: {exc}", file=sys.stderr)
+        return 1
+
+    data = curriculum_to_dict(
+        curriculum,
+        status=args.status,
+        required_only=args.required_only,
+        period=args.period,
+        include_requirements=args.requirements,
+    )
+    if args.json:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    else:
+        _print_curriculum(data)
+    return 0
+
+
+def _cmd_cra(args, settings: Settings) -> int:
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        print("missing credentials (set SIGAA_USER and keyring/SIGAA_PASS)", file=sys.stderr)
+        return 1
+
+    try:
+        with SigaaClient(settings.username, password) as client:
+            cra = client.get_cra()
+    except CraUnavailableError:
+        data = {"value": None, "source": "unavailable"}
+    except (
+        AcademicDocumentError,
+        AuthError,
+        TranscriptParseError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        print(f"CRA lookup failed: {exc}", file=sys.stderr)
+        return 1
+    else:
+        data = {"value": float(cra), "source": "academic_transcript"}
+
+    if args.json:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    elif data["value"] is None:
+        print("CRA: unavailable (the academic transcript does not report one yet)")
+    else:
+        print(f"CRA: {data['value']:.2f}")
+        print("Source: official academic transcript")
     return 0
 
 
@@ -489,6 +594,93 @@ def _cmd_watch(args, settings: Settings) -> int:
     except KeyboardInterrupt:
         print("\nstopped")
     return 0
+
+
+def _print_curriculum(data: dict) -> None:
+    print("Curriculum progress")
+    if data["maximum_completion_term"]:
+        print(f"  Maximum completion term: {data['maximum_completion_term']}")
+
+    cra = data["cra"]
+    if cra["value"] is not None:
+        print(f"  CRA: {cra['value']:.2f} (official academic transcript)")
+    elif cra["source"] == "not_requested":
+        print("  CRA: not requested")
+    else:
+        print("  CRA: unavailable (not reported in the transcript yet)")
+
+    semester = data["semester_workload_hours"]
+    if semester["minimum"] is not None or semester["maximum"] is not None:
+        minimum = semester["minimum"] if semester["minimum"] is not None else "?"
+        maximum = semester["maximum"] if semester["maximum"] is not None else "?"
+        print(f"  Semester workload: {minimum}-{maximum} h")
+
+    print("\nWorkload")
+    if not data["progress"]:
+        print("  No workload progress reported.")
+    for item in data["progress"]:
+        percent = item["completed_percent"]
+        print(
+            f"  {item['description'][:28]:28} "
+            f"{item['completed_hours']:>4}/{item['total_hours']:<4} h "
+            f"{_progress_bar(percent)} {percent:>6.2f}%"
+        )
+
+    group_order = ("enrolled", "pending", "completed", "unknown")
+    group_labels = {
+        "enrolled": "Enrolled",
+        "pending": "Pending",
+        "completed": "Completed",
+        "unknown": "Other status",
+    }
+    components = data["components"]
+    for component_status in group_order:
+        group = [
+            component
+            for component in components
+            if component["status"] == component_status
+        ]
+        if not group:
+            continue
+        print(f"\n{group_labels[component_status]} ({len(group)})")
+        for component in group:
+            period = (
+                f"P{component['period']}"
+                if component["period"] is not None
+                else "other"
+            )
+            nature = "required" if component["required"] else "option"
+            print(
+                f"  {component['code'][:12]:12} "
+                f"{component['workload_hours']:>3} h "
+                f"{period:>6} {nature:8} {component['name']}"
+            )
+            if "prerequisite" in component:
+                print(f"      prerequisite: {component['prerequisite'] or '-'}")
+                print(f"      corequisite:  {component['corequisite'] or '-'}")
+
+    if not components:
+        print("\nNo components match the selected filters.")
+
+    counts = data["counts"]
+    print(
+        "\nSummary: "
+        f"{counts['completed']} completed | "
+        f"{counts['enrolled']} enrolled | "
+        f"{counts['pending_required']} required pending | "
+        f"{counts['pending_optional']} optional choices pending"
+    )
+    if data["query"]["status"] == "current" and counts["pending_optional"]:
+        print(
+            "Optional pending components are choices toward remaining workload, "
+            "not all individually required. Use --status pending to inspect them."
+        )
+
+
+def _progress_bar(percent: float, width: int = 16) -> str:
+    bounded = max(0.0, min(float(percent), 100.0))
+    filled = round((bounded / 100.0) * width)
+    return f"[{'#' * filled}{'-' * (width - filled)}]"
 
 
 def _fmt_schedule(raw: str) -> str:

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+from dataclasses import replace
+from decimal import Decimal
 
 from . import config
 from .documents import (
@@ -18,6 +20,7 @@ from .http import AuthError, Session, extract_viewstate
 from .models import (
     Attendance,
     CoursePlan,
+    CurriculumStatus,
     Deadline,
     Grade,
     Material,
@@ -27,12 +30,14 @@ from .models import (
     TurmaGrade,
 )
 from .parsers import attendance as attendance_parser
+from .parsers import curriculum as curriculum_parser
 from .parsers import grades as grades_parser
 from .parsers import plano as plano_parser
 from .parsers import materials as materials_parser
 from .parsers import news as news_parser
 from .parsers import portal as portal_parser
 from .parsers import tarefa as tarefa_parser
+from .parsers import transcript as transcript_parser
 
 
 class SigaaClient:
@@ -58,6 +63,50 @@ class SigaaClient:
     def get_grades(self) -> list[Grade]:
         html = self._portal_menu_post("Minhas Notas")
         return grades_parser.parse_grades(html)
+
+    def get_cra(self) -> Decimal:
+        """Return the official CRA recorded in the academic transcript."""
+        return transcript_parser.parse_cra_pdf(self.get_historico_pdf())
+
+    def get_curriculum_status(
+        self,
+        *,
+        include_cra: bool = True,
+    ) -> CurriculumStatus:
+        """Return live curriculum progress and, by default, the official CRA.
+
+        SIGAA renders a curriculum shell and then fetches its JSON payload. A
+        fresh login changes the active student context, so an invalid/auth
+        response retries the complete two-request flow once.
+        """
+        status: CurriculumStatus | None = None
+        for attempt in range(2):
+            try:
+                self._session.get(config.CURRICULUM_ENTRY_URL)
+                payload = self._session.get(config.CURRICULUM_DATA_URL)
+                status = curriculum_parser.parse_curriculum(payload)
+                break
+            except (AuthError, curriculum_parser.CurriculumDataError):
+                if attempt == 1:
+                    raise
+                self._portal_html = self._session.login()
+
+        if status is None:  # pragma: no cover - loop either succeeds or raises
+            raise curriculum_parser.CurriculumDataError(
+                "Invalid curriculum response"
+            )
+        if not include_cra:
+            return replace(status, cra_source="not_requested")
+
+        try:
+            cra = self.get_cra()
+        except transcript_parser.CraUnavailableError:
+            return status
+        return replace(
+            status,
+            cra=cra,
+            cra_source="academic_transcript",
+        )
 
     def get_historico_pdf(self) -> bytes:
         """Download the full academic transcript (Histórico) as a PDF."""

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -1,7 +1,8 @@
 """Configuration: endpoints, JSF constants, paths, and credential resolution.
 
-Credentials resolve keyring-first, environment-second. Nothing is ever written
-to disk in plaintext by this module.
+The username resolves from ``SIGAA_USER`` first, then the active account saved
+in keyring. Passwords resolve keyring-first, environment-second. Nothing is ever
+written to disk in plaintext by this module.
 """
 
 from __future__ import annotations
@@ -19,6 +20,9 @@ LOGON_URL = f"{BASE}/logon.jsf"
 PORTAL_ENTRY_URL = f"{BASE}/portal/discente/"
 # Form action used for in-portal JSF postbacks (entering a turma).
 PORTAL_ACTION_URL = f"{BASE}/portais/discente/beta/discente.jsf"
+# Curriculum-progress shell and the JSON request it issues after rendering.
+CURRICULUM_ENTRY_URL = f"{BASE}/portal/discente/integralizacao/"
+CURRICULUM_DATA_URL = f"{BASE}/portal/discente/integralizacao/dados/"
 # Turma Virtual base; news bodies are fetched here.
 AVA_URL = f"{BASE}/ava/index.jsf"
 
@@ -30,6 +34,7 @@ AUTH_MARKER = "Sair do SIGAA"
 LOGIN_REDIRECT_MARKER = "logon.jsf"
 
 KEYRING_SERVICE = "sigaa-ufpb"
+KEYRING_ACTIVE_USERNAME = "__active_username__"
 
 # UFPB class-time slots. Day digits: 2=Mon .. 7=Sat. Shift: M/T/N.
 # NOTE: clock times below are an UNCONFIRMED default; confirm against a turma's
@@ -58,10 +63,24 @@ def default_download_dir() -> Path:
     return default_db_path().parent / "downloads"
 
 
+def default_username() -> str | None:
+    """Return the environment override or the last account saved by login."""
+    username = os.environ.get("SIGAA_USER")
+    if username:
+        return username
+    try:
+        import keyring
+
+        saved = keyring.get_password(KEYRING_SERVICE, KEYRING_ACTIVE_USERNAME)
+        return saved or None
+    except Exception:
+        return None
+
+
 @dataclass
 class Settings:
     db_path: Path = field(default_factory=default_db_path)
-    username: str | None = field(default_factory=lambda: os.environ.get("SIGAA_USER"))
+    username: str | None = field(default_factory=default_username)
 
     def resolve_password(self) -> str | None:
         """keyring first (Keychain), then SIGAA_PASS env var."""

--- a/sigaa/curriculum.py
+++ b/sigaa/curriculum.py
@@ -1,0 +1,138 @@
+"""Shared curriculum filtering and JSON-safe presentation."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from .models import CurriculumComponent, CurriculumStatus
+
+ComponentView = Literal["current", "enrolled", "pending", "completed", "all"]
+COMPONENT_VIEWS: tuple[ComponentView, ...] = (
+    "current",
+    "enrolled",
+    "pending",
+    "completed",
+    "all",
+)
+
+
+def filter_curriculum_components(
+    components: list[CurriculumComponent],
+    *,
+    status: ComponentView = "current",
+    required_only: bool = False,
+    period: int | None = None,
+) -> list[CurriculumComponent]:
+    """Filter components without changing summary counts or progress."""
+    if status not in COMPONENT_VIEWS:
+        choices = ", ".join(COMPONENT_VIEWS)
+        raise ValueError(f"unknown component status {status!r}; choose one of: {choices}")
+
+    selected = []
+    for component in components:
+        if status == "current":
+            visible = component.status == "enrolled" or (
+                component.status == "pending" and component.required
+            )
+        elif status == "all":
+            visible = True
+        else:
+            visible = component.status == status
+        if not visible:
+            continue
+        if required_only and not component.required:
+            continue
+        if period is not None and component.period != period:
+            continue
+        selected.append(component)
+    return selected
+
+
+def curriculum_to_dict(
+    curriculum: CurriculumStatus,
+    *,
+    status: ComponentView = "current",
+    required_only: bool = False,
+    period: int | None = None,
+    include_requirements: bool = False,
+) -> dict:
+    """Return the stable JSON contract shared by CLI and MCP."""
+    selected = filter_curriculum_components(
+        curriculum.components,
+        status=status,
+        required_only=required_only,
+        period=period,
+    )
+    counts = {
+        state: sum(component.status == state for component in curriculum.components)
+        for state in ("completed", "enrolled", "pending", "unknown")
+    }
+    counts["pending_required"] = sum(
+        component.status == "pending" and component.required
+        for component in curriculum.components
+    )
+    counts["pending_optional"] = sum(
+        component.status == "pending" and not component.required
+        for component in curriculum.components
+    )
+
+    return {
+        "schema_version": 1,
+        "curriculum": curriculum.curriculum,
+        "maximum_completion_term": curriculum.maximum_completion_term,
+        "semester_workload_hours": {
+            "minimum": curriculum.min_semester_workload_hours,
+            "maximum": curriculum.max_semester_workload_hours,
+        },
+        "cra": {
+            "value": float(curriculum.cra) if curriculum.cra is not None else None,
+            "source": curriculum.cra_source,
+        },
+        "progress": [
+            {
+                "description": item.description,
+                "completed_hours": item.completed_hours,
+                "total_hours": item.total_hours,
+                "remaining_hours": max(item.total_hours - item.completed_hours, 0),
+                "completed_percent": item.completed_percent,
+            }
+            for item in curriculum.progress
+        ],
+        "counts": counts,
+        "query": {
+            "status": status,
+            "required_only": required_only,
+            "period": period,
+            "include_requirements": include_requirements,
+        },
+        "returned_count": len(selected),
+        "components": [
+            _component_to_dict(
+                component,
+                include_requirements=include_requirements,
+            )
+            for component in selected
+        ],
+    }
+
+
+def _component_to_dict(
+    component: CurriculumComponent,
+    *,
+    include_requirements: bool,
+) -> dict:
+    data = {
+        "code": component.code,
+        "name": component.name,
+        "status": component.status,
+        "status_raw": component.status_raw,
+        "required": component.required,
+        "period": component.period,
+        "period_raw": component.period_raw,
+        "workload_hours": component.workload_hours,
+        "integration_type": component.integration_type,
+    }
+    if include_requirements:
+        data["prerequisite"] = component.prerequisite
+        data["corequisite"] = component.corequisite
+    return data

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -13,23 +13,30 @@ import re
 import secrets
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
+import httpx
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import CallToolResult, ResourceLink, TextContent
 
 from .client import SigaaClient
 from .config import Settings, default_download_dir
+from .curriculum import curriculum_to_dict
 from .documents import (
     ATESTADO_MATRICULA,
     DECLARACAO_VINCULO,
     HISTORICO,
+    AcademicDocumentError,
     document_spec,
     sanitize_download_filename,
     write_academic_document,
 )
 from .exporters.ics import build_calendar
+from .http import AuthError
+from .parsers.curriculum import CurriculumDataError
 from .parsers.schedule import day_name, decode_schedule
+from .parsers.transcript import CraUnavailableError, TranscriptParseError
 from .services import whatsnew
 from .services.sync import sync as run_sync
 from .store.db import connect
@@ -190,6 +197,69 @@ def sigaa_list_grades(semester: str | None = None) -> list[dict]:
         }
         for g in _repo().get_grades(semester=semester)
     ]
+
+
+@mcp.tool()
+def sigaa_get_cra() -> dict:
+    """Get the official CRA recorded in the academic transcript. Networked."""
+    settings = Settings()
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        raise ToolError("no credentials available")
+    try:
+        with SigaaClient(settings.username, password) as client:
+            cra = client.get_cra()
+    except CraUnavailableError:
+        return {"value": None, "source": "unavailable"}
+    except (
+        AcademicDocumentError,
+        AuthError,
+        TranscriptParseError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        raise ToolError(f"CRA lookup failed: {exc}") from None
+    return {"value": float(cra), "source": "academic_transcript"}
+
+
+@mcp.tool()
+def sigaa_get_curriculum(
+    status: Literal["current", "enrolled", "pending", "completed", "all"] = "current",
+    required_only: bool = False,
+    period: int | None = None,
+    include_requirements: bool = False,
+    include_cra: bool = True,
+) -> dict:
+    """Get live curriculum progress and components.
+
+    The default component view returns currently enrolled components plus
+    required pending ones. Use status="pending" to inspect optional choices;
+    they are alternatives toward workload requirements, not all individually
+    required. CRA comes from the official transcript. This tool is networked.
+    """
+    settings = Settings()
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        raise ToolError("no credentials available")
+    try:
+        with SigaaClient(settings.username, password) as client:
+            curriculum = client.get_curriculum_status(include_cra=include_cra)
+        return curriculum_to_dict(
+            curriculum,
+            status=status,
+            required_only=required_only,
+            period=period,
+            include_requirements=include_requirements,
+        )
+    except (
+        AcademicDocumentError,
+        AuthError,
+        CurriculumDataError,
+        TranscriptParseError,
+        ValueError,
+        httpx.HTTPError,
+    ) as exc:
+        raise ToolError(f"curriculum lookup failed: {exc}") from None
 
 
 @mcp.tool()

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from decimal import Decimal
 
 
 @dataclass
@@ -50,6 +51,62 @@ class NewsItem:
     body: str | None = None
     # JSF form id for the per-row "Visualizar" body postback.
     form_id: str | None = None
+
+
+@dataclass
+class WorkloadProgress:
+    """Completed workload for one curriculum integration category.
+
+    SIGAA reports ``porcentagem`` as the percentage still remaining. The
+    normalized model exposes the percentage already completed instead.
+    """
+
+    description: str
+    completed_hours: int
+    total_hours: int
+    completed_percent: float
+    remaining_percent_raw: str | int | float | None = None
+
+
+@dataclass
+class CurriculumComponent:
+    """One component in the student's curriculum status.
+
+    ``integration_type`` keeps SIGAA's raw code (for example, ``OB`` or
+    ``OP``). ``status`` is normalized for consumers while ``status_raw``
+    retains the source value.
+    """
+
+    code: str
+    name: str
+    integration_type: str
+    period: int | None
+    workload_hours: int
+    required: bool
+    status: str
+    status_raw: str | None
+    prerequisite: str | None = None
+    corequisite: str | None = None
+    period_raw: int | float | str | None = None
+
+
+@dataclass
+class CurriculumStatus:
+    """A privacy-safe view of curriculum progress.
+
+    SIGAA's student id is deliberately not represented by this model.
+    ``cra`` is composed from an official grade-history source because the
+    curriculum integration endpoint does not provide it.
+    """
+
+    curriculum: str
+    max_semester_workload_hours: int | None
+    min_semester_workload_hours: int | None
+    maximum_completion_term: str | None
+    progress: list[WorkloadProgress] = field(default_factory=list)
+    components: list[CurriculumComponent] = field(default_factory=list)
+    cra: Decimal | None = None
+    cra_source: str = "unavailable"
 
 
 @dataclass

--- a/sigaa/parsers/curriculum.py
+++ b/sigaa/parsers/curriculum.py
@@ -1,0 +1,225 @@
+"""Parse SIGAA's curriculum integration JSON response."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+from ..models import CurriculumComponent, CurriculumStatus, WorkloadProgress
+
+
+class CurriculumDataError(ValueError):
+    """Raised when SIGAA does not return a valid curriculum payload."""
+
+
+_STATUS_MAP = {
+    "CONCLUIDO": "completed",
+    "MATRICULADO": "enrolled",
+    "PENDENTE": "pending",
+}
+
+
+def parse_curriculum(data: object) -> CurriculumStatus:
+    """Validate and normalize a curriculum integration payload.
+
+    ``data`` may be an already-decoded JSON object, a JSON string, or UTF-8
+    bytes. Error messages intentionally omit response bodies because an
+    authentication failure can return a page containing private data.
+    """
+
+    payload = _decode_payload(data)
+    progress_data = _required_list(payload, "integralizacoes")
+    components_data = _required_list(payload, "disciplinas")
+
+    progress = [
+        _parse_progress(item, index)
+        for index, item in enumerate(progress_data)
+    ]
+    components = [
+        _parse_component(item, index)
+        for index, item in enumerate(components_data)
+    ]
+
+    return CurriculumStatus(
+        curriculum=_required_string(payload, "curriculo"),
+        max_semester_workload_hours=_optional_int(
+            payload.get("cargaHorariaMaximaSemestre")
+        ),
+        min_semester_workload_hours=_optional_int(
+            payload.get("cargaHorariaMinimaSemestre")
+        ),
+        maximum_completion_term=_optional_string(payload.get("prazoMaximo")),
+        progress=progress,
+        components=components,
+    )
+
+
+def _decode_payload(data: object) -> dict[str, Any]:
+    decoded: object
+    if isinstance(data, bytes):
+        try:
+            decoded = json.loads(data.decode("utf-8-sig"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            raise CurriculumDataError("Invalid curriculum response") from None
+    elif isinstance(data, str):
+        try:
+            decoded = json.loads(data)
+        except json.JSONDecodeError:
+            raise CurriculumDataError("Invalid curriculum response") from None
+    else:
+        decoded = data
+
+    if not isinstance(decoded, dict):
+        raise CurriculumDataError("Invalid curriculum response")
+    return decoded
+
+
+def _required_list(payload: dict[str, Any], key: str) -> list[object]:
+    value = payload.get(key)
+    if not isinstance(value, list):
+        raise CurriculumDataError(f"Invalid curriculum field: {key}")
+    return value
+
+
+def _required_string(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CurriculumDataError(f"Invalid curriculum field: {key}")
+    return value.strip()
+
+
+def _parse_progress(item: object, index: int) -> WorkloadProgress:
+    if not isinstance(item, dict):
+        raise CurriculumDataError(
+            f"Invalid curriculum progress entry at index {index}"
+        )
+
+    completed = _required_non_negative_int(item.get("concluido"), "concluido")
+    total = _required_non_negative_int(item.get("total"), "total")
+    remaining_raw = item.get("porcentagem")
+    reported_completed = _completed_from_remaining(remaining_raw)
+
+    if total > 0:
+        completed_percent = round((completed / total) * 100, 2)
+    elif completed == 0 and reported_completed is not None:
+        completed_percent = reported_completed
+    else:
+        completed_percent = 0.0
+
+    if not isinstance(remaining_raw, (str, int, float)) or isinstance(
+        remaining_raw, bool
+    ):
+        remaining_raw = None
+
+    return WorkloadProgress(
+        description=_required_string(item, "descricao"),
+        completed_hours=completed,
+        total_hours=total,
+        completed_percent=completed_percent,
+        remaining_percent_raw=remaining_raw,
+    )
+
+
+def _completed_from_remaining(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        normalized = value.strip().replace(",", ".")
+        if not normalized:
+            return None
+        try:
+            remaining = float(normalized)
+        except ValueError:
+            return None
+    elif isinstance(value, (int, float)):
+        remaining = float(value)
+    else:
+        return None
+
+    if not math.isfinite(remaining):
+        return None
+    return round(100.0 - remaining, 2)
+
+
+def _parse_component(item: object, index: int) -> CurriculumComponent:
+    if not isinstance(item, dict):
+        raise CurriculumDataError(
+            f"Invalid curriculum component entry at index {index}"
+        )
+
+    period_raw = item.get("periodo")
+    period_number = _optional_int(period_raw)
+    period = period_number if period_number is not None and period_number > 0 else None
+
+    status_raw = item.get("situacao")
+    if status_raw is not None and not isinstance(status_raw, str):
+        raise CurriculumDataError(
+            f"Invalid curriculum component status at index {index}"
+        )
+    status_key = status_raw.strip().upper() if status_raw is not None else ""
+    status = _STATUS_MAP.get(status_key, "unknown")
+
+    required = item.get("obrigatoria")
+    if not isinstance(required, bool):
+        raise CurriculumDataError(
+            f"Invalid curriculum component requirement at index {index}"
+        )
+
+    return CurriculumComponent(
+        code=_required_string(item, "codigo"),
+        name=_required_string(item, "nome"),
+        integration_type=_required_string(item, "tipoIntegralizacao"),
+        period=period,
+        workload_hours=_required_non_negative_int(
+            item.get("cargaHoraria"), "cargaHoraria"
+        ),
+        required=required,
+        status=status,
+        status_raw=status_raw,
+        prerequisite=_optional_string(item.get("expressaoPreRequisito")),
+        corequisite=_optional_string(item.get("expressaoCoRequisito")),
+        period_raw=_safe_raw_period(period_raw),
+    )
+
+
+def _required_non_negative_int(value: object, field: str) -> int:
+    parsed = _optional_int(value)
+    if parsed is None or parsed < 0:
+        raise CurriculumDataError(f"Invalid curriculum field: {field}")
+    return parsed
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value) or not value.is_integer():
+            return None
+        return int(value)
+    if isinstance(value, str):
+        normalized = value.strip()
+        if not normalized:
+            return None
+        try:
+            return int(normalized)
+        except ValueError:
+            return None
+    return None
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _safe_raw_period(value: object) -> int | float | str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float, str)):
+        return value
+    return None

--- a/sigaa/parsers/transcript.py
+++ b/sigaa/parsers/transcript.py
@@ -1,0 +1,265 @@
+"""Extract the official CRA value from an academic transcript.
+
+The PDF entry point keeps the private document in memory and returns only a
+``Decimal``. Public errors are deliberately static so malformed documents
+cannot leak transcript text or bytes through exception messages.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from decimal import Decimal, InvalidOperation
+from io import BytesIO
+
+from pypdf import PdfReader
+
+
+class TranscriptParseError(ValueError):
+    """The transcript is invalid or does not expose an unambiguous CRA."""
+
+
+class CraUnavailableError(TranscriptParseError):
+    """The transcript is valid but does not report a CRA yet."""
+
+
+_CRA_LABEL_RE = re.compile(
+    r"(?<![A-Za-z0-9])C[\s._-]*R[\s._-]*A(?![A-Za-z0-9])",
+    re.IGNORECASE,
+)
+_NUMBER_RE = re.compile(
+    r"(?<![\d.,])[-+]?\d{1,3}(?:[.,]\d+)?(?![\d.,])"
+)
+_VALUE_DELIMITER_RE = re.compile(r"[:=]")
+_NON_WHITESPACE_RE = re.compile(r"\S+")
+_MAX_ADJACENT_LINES = 3
+# SIGAA centers the boxed CRA value farther right than its label in the
+# layout-extracted text. Neighboring table headers still provide tighter cell
+# bounds when they exist.
+_MAX_COLUMN_DISTANCE = 40
+_MIN_CRA = Decimal("0.00")
+_MAX_CRA = Decimal("10.00")
+
+
+def parse_cra_pdf(content: bytes | bytearray | memoryview) -> Decimal:
+    """Return the transcript's official CRA from PDF bytes.
+
+    The PDF is validated and parsed directly from memory. The returned
+    ``Decimal`` is always between ``0.00`` and ``10.00``, inclusive.
+    """
+
+    if not isinstance(content, (bytes, bytearray, memoryview)):
+        raise TypeError("transcript PDF content must be bytes")
+
+    pdf_bytes = bytes(content)
+    if not pdf_bytes.startswith(b"%PDF-"):
+        raise TranscriptParseError("transcript content is not a valid PDF")
+
+    try:
+        reader = PdfReader(BytesIO(pdf_bytes), strict=False)
+        if reader.is_encrypted:
+            raise TranscriptParseError("encrypted transcripts are not supported")
+        if not reader.pages:
+            raise TranscriptParseError("transcript PDF contains no pages")
+
+        page_text = []
+        for page in reader.pages:
+            text = page.extract_text(extraction_mode="layout")
+            if text:
+                page_text.append(text)
+    except TranscriptParseError:
+        raise
+    except Exception:
+        raise TranscriptParseError("transcript PDF could not be read") from None
+
+    if not page_text:
+        raise TranscriptParseError("transcript PDF contains no readable text")
+    return parse_cra_text("\n".join(page_text))
+
+
+def parse_cra_text(text: str) -> Decimal:
+    """Return the CRA associated with a ``CRA`` label in extracted PDF text.
+
+    The value may share the label's line or appear up to three lines below it.
+    Bare labels also support a preceding value, while explicit ``CRA:`` and
+    ``CRA =`` fields never fall back upward. Comma and dot decimal separators
+    are accepted. Conflicting repeated values fail instead of being guessed.
+    """
+
+    if not isinstance(text, str):
+        raise TypeError("transcript text must be a string")
+
+    normalized = unicodedata.normalize("NFKC", text).replace("\r\n", "\n")
+    lines = normalized.replace("\r", "\n").split("\n")
+    labels = [
+        (line_index, match)
+        for line_index, line in enumerate(lines)
+        for match in _CRA_LABEL_RE.finditer(line)
+    ]
+    if not labels:
+        raise CraUnavailableError("CRA is not available in transcript")
+
+    values: list[Decimal] = []
+    for line_index, label in labels:
+        raw_value = _find_value_for_label(lines, line_index, label)
+        if raw_value is not None:
+            values.append(_parse_cra_value(raw_value))
+
+    if not values:
+        raise CraUnavailableError("CRA is not available in transcript")
+
+    distinct_values = set(values)
+    if len(distinct_values) != 1:
+        raise TranscriptParseError("transcript contains conflicting CRA values")
+    return distinct_values.pop()
+
+
+def _find_value_for_label(
+    lines: list[str],
+    line_index: int,
+    label: re.Match[str],
+) -> str | None:
+    line = lines[line_index]
+    column_bounds = _label_column_bounds(line, label)
+    after_label = line[label.end() :]
+
+    explicit_delimiter = _VALUE_DELIMITER_RE.search(after_label)
+    if explicit_delimiter is not None:
+        candidate = _first_number(after_label[explicit_delimiter.end() :])
+        if candidate is not None:
+            return candidate
+    else:
+        candidate = _first_number(after_label)
+        if candidate is not None:
+            return candidate
+
+        before_label = line[: label.start()]
+        candidates_before = list(_NUMBER_RE.finditer(before_label))
+        if candidates_before:
+            return candidates_before[-1].group(0)
+
+    for distance in range(1, _MAX_ADJACENT_LINES + 1):
+        adjacent_index = line_index + distance
+        if adjacent_index < len(lines):
+            candidate = _number_nearest_column(
+                lines[adjacent_index],
+                label.start(),
+                column_bounds=column_bounds,
+            )
+            if candidate is not None:
+                return candidate
+
+    # ``CRA:`` and ``CRA =`` introduce a value on the same line or below.
+    # Looking above them can capture an unrelated field such as the current
+    # academic period.
+    if explicit_delimiter is not None:
+        return None
+
+    for distance in range(1, _MAX_ADJACENT_LINES + 1):
+        adjacent_index = line_index - distance
+        if adjacent_index >= 0:
+            candidate = _number_nearest_column(
+                lines[adjacent_index],
+                label.start(),
+                column_bounds=column_bounds,
+            )
+            if candidate is not None:
+                return candidate
+
+    return None
+
+
+def _first_number(text: str) -> str | None:
+    match = _NUMBER_RE.search(text)
+    return match.group(0) if match is not None else None
+
+
+def _label_column_bounds(
+    line: str,
+    label: re.Match[str],
+) -> tuple[float | None, float | None]:
+    """Bound an adjacent value to the CRA cell in a layout-extracted table."""
+    tokens = list(_NON_WHITESPACE_RE.finditer(line))
+    previous = next(
+        (
+            token
+            for token in reversed(tokens)
+            if token.end() <= label.start()
+            and line[token.end() : label.start()].isspace()
+            and len(line[token.end() : label.start()]) >= 2
+        ),
+        None,
+    )
+    following = next(
+        (
+            token
+            for token in tokens
+            if token.start() >= label.end()
+            and line[label.end() : token.start()].isspace()
+            and len(line[label.end() : token.start()]) >= 2
+        ),
+        None,
+    )
+
+    left = (
+        (previous.start() + label.start()) / 2
+        if previous is not None
+        else None
+    )
+    right = (
+        (label.start() + following.start()) / 2
+        if following is not None
+        else None
+    )
+    return left, right
+
+
+def _number_nearest_column(
+    line: str,
+    label_column: int,
+    *,
+    column_bounds: tuple[float | None, float | None],
+) -> str | None:
+    matches = list(_NUMBER_RE.finditer(line))
+    if not matches:
+        return None
+
+    left, right = column_bounds
+    matches = [
+        match
+        for match in matches
+        if (left is None or match.start() >= left)
+        and (right is None or match.start() < right)
+        and abs(match.start() - label_column) <= _MAX_COLUMN_DISTANCE
+    ]
+    if not matches:
+        return None
+
+    valid_matches = [
+        match for match in matches if _value_in_range(match.group(0))
+    ]
+    candidates = valid_matches or matches
+    nearest = min(
+        candidates,
+        key=lambda match: (abs(match.start() - label_column), match.start()),
+    )
+    return nearest.group(0)
+
+
+def _value_in_range(raw_value: str) -> bool:
+    try:
+        value = Decimal(raw_value.replace(",", "."))
+    except InvalidOperation:
+        return False
+    return value.is_finite() and _MIN_CRA <= value <= _MAX_CRA
+
+
+def _parse_cra_value(raw_value: str) -> Decimal:
+    try:
+        value = Decimal(raw_value.replace(",", "."))
+    except InvalidOperation:
+        raise TranscriptParseError("CRA value is invalid") from None
+
+    if not value.is_finite() or not _MIN_CRA <= value <= _MAX_CRA:
+        raise TranscriptParseError("CRA value is outside the supported range")
+    return value

--- a/sigaa/setup_wizard.py
+++ b/sigaa/setup_wizard.py
@@ -52,18 +52,26 @@ def select_institution(input_func: Callable[[str], str] = input) -> Institution:
 
 
 def verify_and_store_login(username: str, password: str) -> LoginResult:
+    with SigaaClient(username, password) as client:
+        student = client.get_student()
+
     password_stored = True
     storage_message = "password stored in keyring"
     try:
         import keyring
 
         keyring.set_password(config.KEYRING_SERVICE, username, password)
+        keyring.set_password(
+            config.KEYRING_SERVICE,
+            config.KEYRING_ACTIVE_USERNAME,
+            username,
+        )
     except Exception:
         password_stored = False
-        storage_message = "keyring unavailable; set SIGAA_PASS in your shell"
+        storage_message = (
+            "keyring unavailable; set SIGAA_USER and SIGAA_PASS in your shell"
+        )
 
-    with SigaaClient(username, password) as client:
-        student = client.get_student()
     return LoginResult(
         name=student.name,
         matricula=student.matricula,

--- a/tests/fixtures/curriculum.json
+++ b/tests/fixtures/curriculum.json
@@ -1,0 +1,71 @@
+{
+  "idDiscente": 999999,
+  "curriculo": "999999 - 2099.1",
+  "cargaHorariaMaximaSemestre": 480,
+  "cargaHorariaMinimaSemestre": 240,
+  "prazoMaximo": "2104.2",
+  "integralizacoes": [
+    {
+      "descricao": "Total",
+      "concluido": 120,
+      "total": 300,
+      "porcentagem": "60,00"
+    },
+    {
+      "descricao": "Complementar Optativa",
+      "concluido": 30,
+      "total": 60,
+      "porcentagem": "50.00"
+    }
+  ],
+  "integralizacaoSemestre": [],
+  "disciplinas": [
+    {
+      "codigo": "SYN0001",
+      "nome": "COMPONENTE SINTETICO CONCLUIDO",
+      "tipoIntegralizacao": "OB",
+      "periodo": 1,
+      "cargaHoraria": 60,
+      "obrigatoria": true,
+      "situacao": "CONCLUIDO"
+    },
+    {
+      "codigo": "SYN0002",
+      "nome": "COMPONENTE SINTETICO MATRICULADO",
+      "tipoIntegralizacao": "EC",
+      "periodo": -1,
+      "cargaHoraria": 30,
+      "obrigatoria": false,
+      "situacao": "MATRICULADO"
+    },
+    {
+      "codigo": "SYN0003",
+      "nome": "COMPONENTE SINTETICO PENDENTE",
+      "tipoIntegralizacao": "OB",
+      "periodo": 2,
+      "expressaoPreRequisito": "( SYN0001 )",
+      "expressaoCoRequisito": "( SYN0004 )",
+      "cargaHoraria": 60,
+      "obrigatoria": true,
+      "situacao": "PENDENTE"
+    },
+    {
+      "codigo": "SYN0004",
+      "nome": "OPTATIVA SINTETICA DISPONIVEL",
+      "tipoIntegralizacao": "OP",
+      "periodo": 0,
+      "cargaHoraria": 45,
+      "obrigatoria": false,
+      "situacao": "PENDENTE"
+    },
+    {
+      "codigo": "SYN0005",
+      "nome": "COMPONENTE SINTETICO EM ANALISE",
+      "tipoIntegralizacao": "ZX",
+      "periodo": 3,
+      "cargaHoraria": 15,
+      "obrigatoria": false,
+      "situacao": "EM_ANALISE"
+    }
+  ]
+}

--- a/tests/test_curriculum_cli.py
+++ b/tests/test_curriculum_cli.py
@@ -1,0 +1,137 @@
+from dataclasses import replace
+from decimal import Decimal
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from sigaa import cli as cli_module
+from sigaa.parsers.curriculum import parse_curriculum
+from sigaa.parsers.transcript import CraUnavailableError
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "curriculum.json"
+
+
+def _curriculum():
+    return replace(
+        parse_curriculum(FIXTURE.read_text(encoding="utf-8")),
+        cra=Decimal("8.42"),
+        cra_source="academic_transcript",
+    )
+
+
+def _settings():
+    return SimpleNamespace(
+        username="configured-user",
+        resolve_password=lambda: "test-password",
+    )
+
+
+def test_cli_registers_curriculum_and_cra_commands():
+    parser = cli_module._build_parser()
+
+    curriculum = parser.parse_args(["curriculum"])
+    cra = parser.parse_args(["cra"])
+
+    assert curriculum.status == "current"
+    assert curriculum.required_only is False
+    assert curriculum.requirements is False
+    assert curriculum.no_cra is False
+    assert cra.json is False
+
+
+def test_curriculum_json_uses_shared_filtered_contract(monkeypatch, capsys):
+    class FakeClient:
+        def __init__(self, username, password):
+            assert (username, password) == ("configured-user", "test-password")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_curriculum_status(self, *, include_cra):
+            assert include_cra is True
+            return _curriculum()
+
+    monkeypatch.setattr(cli_module, "SigaaClient", FakeClient)
+    args = cli_module._build_parser().parse_args(
+        ["curriculum", "--status", "pending", "--requirements", "--json"]
+    )
+
+    assert cli_module._cmd_curriculum(args, _settings()) == 0
+    data = json.loads(capsys.readouterr().out)
+
+    assert data["cra"] == {"value": 8.42, "source": "academic_transcript"}
+    assert {component["code"] for component in data["components"]} == {
+        "SYN0003",
+        "SYN0004",
+    }
+    assert all("prerequisite" in component for component in data["components"])
+    assert "idDiscente" not in json.dumps(data)
+
+
+def test_curriculum_human_view_is_compact_and_explains_optional_choices(
+    monkeypatch,
+    capsys,
+):
+    class FakeClient:
+        def __init__(self, username, password):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_curriculum_status(self, *, include_cra):
+            return _curriculum()
+
+    monkeypatch.setattr(cli_module, "SigaaClient", FakeClient)
+    args = cli_module._build_parser().parse_args(["curriculum"])
+
+    assert cli_module._cmd_curriculum(args, _settings()) == 0
+    output = capsys.readouterr().out
+
+    assert "CRA: 8.42" in output
+    assert "Curriculum:" not in output
+    assert "Enrolled (1)" in output
+    assert "Pending (1)" in output
+    assert "SYN0002" in output
+    assert "SYN0003" in output
+    assert "SYN0004" not in output
+    assert "not all individually required" in output
+
+
+def test_cra_command_returns_unavailable_as_valid_state(monkeypatch, capsys):
+    class FakeClient:
+        def __init__(self, username, password):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_cra(self):
+            raise CraUnavailableError("CRA is not available in transcript")
+
+    monkeypatch.setattr(cli_module, "SigaaClient", FakeClient)
+    args = cli_module._build_parser().parse_args(["cra", "--json"])
+
+    assert cli_module._cmd_cra(args, _settings()) == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "value": None,
+        "source": "unavailable",
+    }
+
+
+def test_curriculum_requires_credentials(capsys):
+    settings = SimpleNamespace(username=None, resolve_password=lambda: None)
+    args = cli_module._build_parser().parse_args(["curriculum"])
+
+    assert cli_module._cmd_curriculum(args, settings) == 1
+    assert "missing credentials" in capsys.readouterr().err

--- a/tests/test_curriculum_client.py
+++ b/tests/test_curriculum_client.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from sigaa import config
+from sigaa.client import SigaaClient
+from sigaa.parsers.curriculum import CurriculumDataError
+from sigaa.parsers.transcript import CraUnavailableError
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "curriculum.json"
+CURRICULUM_JSON = FIXTURE.read_text(encoding="utf-8")
+
+
+class _CurriculumSession:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.gets: list[str] = []
+        self.login_count = 0
+
+    def get(self, url: str) -> str:
+        self.gets.append(url)
+        result = next(self.responses)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def login(self) -> str:
+        self.login_count += 1
+        return "<html>fresh portal</html>"
+
+
+def _client_with(session: _CurriculumSession) -> SigaaClient:
+    client = object.__new__(SigaaClient)
+    client._session = session
+    client._portal_html = "<html>stale portal</html>"
+    return client
+
+
+def test_client_fetches_curriculum_shell_then_json():
+    session = _CurriculumSession(["<html>curriculum shell</html>", CURRICULUM_JSON])
+    client = _client_with(session)
+
+    status = client.get_curriculum_status(include_cra=False)
+
+    assert status.curriculum == "999999 - 2099.1"
+    assert status.cra_source == "not_requested"
+    assert session.gets == [
+        config.CURRICULUM_ENTRY_URL,
+        config.CURRICULUM_DATA_URL,
+    ]
+    assert session.login_count == 0
+
+
+def test_client_retries_the_complete_flow_after_invalid_payload():
+    session = _CurriculumSession(
+        [
+            "<html>first shell</html>",
+            "<html>expired login</html>",
+            "<html>fresh shell</html>",
+            CURRICULUM_JSON,
+        ]
+    )
+    client = _client_with(session)
+
+    status = client.get_curriculum_status(include_cra=False)
+
+    assert status.components
+    assert session.login_count == 1
+    assert session.gets == [
+        config.CURRICULUM_ENTRY_URL,
+        config.CURRICULUM_DATA_URL,
+        config.CURRICULUM_ENTRY_URL,
+        config.CURRICULUM_DATA_URL,
+    ]
+    assert client._portal_html == "<html>fresh portal</html>"
+
+
+def test_client_surfaces_sanitized_error_after_one_retry():
+    private_html = "<html>student-private-data</html>"
+    session = _CurriculumSession(
+        ["<html>shell</html>", private_html, "<html>shell</html>", private_html]
+    )
+    client = _client_with(session)
+
+    with pytest.raises(CurriculumDataError) as exc_info:
+        client.get_curriculum_status(include_cra=False)
+
+    assert "student-private-data" not in str(exc_info.value)
+    assert session.login_count == 1
+
+
+def test_client_composes_cra_from_transcript(monkeypatch):
+    session = _CurriculumSession(["<html>shell</html>", CURRICULUM_JSON])
+    client = _client_with(session)
+    monkeypatch.setattr(client, "get_cra", lambda: Decimal("8.42"))
+
+    status = client.get_curriculum_status()
+
+    assert status.cra == Decimal("8.42")
+    assert status.cra_source == "academic_transcript"
+
+
+def test_client_keeps_curriculum_when_transcript_has_no_cra(monkeypatch):
+    session = _CurriculumSession(["<html>shell</html>", CURRICULUM_JSON])
+    client = _client_with(session)
+
+    def unavailable():
+        raise CraUnavailableError("CRA is not available in transcript")
+
+    monkeypatch.setattr(client, "get_cra", unavailable)
+
+    status = client.get_curriculum_status()
+
+    assert status.cra is None
+    assert status.cra_source == "unavailable"

--- a/tests/test_curriculum_parser.py
+++ b/tests/test_curriculum_parser.py
@@ -1,0 +1,97 @@
+from dataclasses import asdict
+import json
+from pathlib import Path
+
+import pytest
+
+from sigaa.parsers.curriculum import CurriculumDataError, parse_curriculum
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "curriculum.json"
+
+
+def test_parse_curriculum_normalizes_progress_without_student_id():
+    curriculum = parse_curriculum(FIXTURE.read_text(encoding="utf-8"))
+
+    assert curriculum.curriculum == "999999 - 2099.1"
+    assert curriculum.max_semester_workload_hours == 480
+    assert curriculum.min_semester_workload_hours == 240
+    assert curriculum.maximum_completion_term == "2104.2"
+    assert curriculum.cra is None
+    assert curriculum.cra_source == "unavailable"
+
+    total = curriculum.progress[0]
+    assert total.completed_hours == 120
+    assert total.total_hours == 300
+    assert total.completed_percent == 40.0
+    assert total.remaining_percent_raw == "60,00"
+
+    serialized = json.dumps(asdict(curriculum), default=str)
+    assert "idDiscente" not in serialized
+
+
+def test_parse_curriculum_normalizes_states_and_preserves_raw_values():
+    curriculum = parse_curriculum(FIXTURE.read_bytes())
+    by_code = {component.code: component for component in curriculum.components}
+
+    assert by_code["SYN0001"].status == "completed"
+    assert by_code["SYN0001"].status_raw == "CONCLUIDO"
+    assert by_code["SYN0002"].status == "enrolled"
+    assert by_code["SYN0002"].period is None
+    assert by_code["SYN0002"].period_raw == -1
+    assert by_code["SYN0003"].status == "pending"
+    assert by_code["SYN0004"].period is None
+    assert by_code["SYN0004"].period_raw == 0
+    assert by_code["SYN0005"].status == "unknown"
+    assert by_code["SYN0005"].status_raw == "EM_ANALISE"
+    assert by_code["SYN0005"].integration_type == "ZX"
+
+
+def test_optional_pending_components_remain_optional():
+    curriculum = parse_curriculum(FIXTURE.read_text(encoding="utf-8"))
+    pending = [
+        component
+        for component in curriculum.components
+        if component.status == "pending"
+    ]
+
+    assert {component.required for component in pending} == {True, False}
+    assert next(c for c in pending if c.code == "SYN0004").required is False
+
+
+def test_prerequisites_and_corequisites_are_optional():
+    curriculum = parse_curriculum(FIXTURE.read_text(encoding="utf-8"))
+    by_code = {component.code: component for component in curriculum.components}
+
+    assert by_code["SYN0001"].prerequisite is None
+    assert by_code["SYN0001"].corequisite is None
+    assert by_code["SYN0003"].prerequisite == "( SYN0001 )"
+    assert by_code["SYN0003"].corequisite == "( SYN0004 )"
+
+
+def test_completed_percent_uses_workload_as_source_of_truth():
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    payload["integralizacoes"][0]["porcentagem"] = "99,99"
+
+    curriculum = parse_curriculum(payload)
+
+    assert curriculum.progress[0].completed_percent == 40.0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "<html><body>sessao expirada</body></html>",
+        b"<html><body>login</body></html>",
+        '{"curriculo": "sintetico"}',
+        [],
+    ],
+)
+def test_invalid_payload_raises_without_echoing_body(payload):
+    with pytest.raises(CurriculumDataError) as exc_info:
+        parse_curriculum(payload)
+
+    message = str(exc_info.value)
+    assert "sessao expirada" not in message
+    assert "<html>" not in message
+    assert "login" not in message

--- a/tests/test_curriculum_view.py
+++ b/tests/test_curriculum_view.py
@@ -1,0 +1,87 @@
+from dataclasses import replace
+from decimal import Decimal
+import json
+from pathlib import Path
+
+from sigaa.curriculum import curriculum_to_dict, filter_curriculum_components
+from sigaa.parsers.curriculum import parse_curriculum
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "curriculum.json"
+
+
+def _curriculum():
+    return parse_curriculum(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_current_view_returns_enrolled_and_required_pending_only():
+    curriculum = _curriculum()
+
+    selected = filter_curriculum_components(curriculum.components)
+
+    assert {component.code for component in selected} == {"SYN0002", "SYN0003"}
+
+
+def test_filters_compose_without_changing_source_components():
+    curriculum = _curriculum()
+
+    selected = filter_curriculum_components(
+        curriculum.components,
+        status="pending",
+        required_only=True,
+        period=2,
+    )
+
+    assert [component.code for component in selected] == ["SYN0003"]
+    assert len(curriculum.components) == 5
+
+
+def test_json_contract_is_private_and_exposes_official_cra_source():
+    curriculum = replace(
+        _curriculum(),
+        cra=Decimal("8.42"),
+        cra_source="academic_transcript",
+    )
+
+    data = curriculum_to_dict(curriculum, status="all")
+
+    assert data["schema_version"] == 1
+    assert data["cra"] == {"value": 8.42, "source": "academic_transcript"}
+    assert data["counts"] == {
+        "completed": 1,
+        "enrolled": 1,
+        "pending": 2,
+        "unknown": 1,
+        "pending_required": 1,
+        "pending_optional": 1,
+    }
+    assert data["returned_count"] == 5
+    assert "idDiscente" not in json.dumps(data)
+
+
+def test_requirements_are_opt_in():
+    curriculum = _curriculum()
+
+    compact = curriculum_to_dict(curriculum, status="pending")
+    detailed = curriculum_to_dict(
+        curriculum,
+        status="pending",
+        include_requirements=True,
+    )
+
+    assert "prerequisite" not in compact["components"][0]
+    by_code = {item["code"]: item for item in detailed["components"]}
+    assert by_code["SYN0003"]["prerequisite"] == "( SYN0001 )"
+    assert by_code["SYN0004"]["prerequisite"] is None
+
+
+def test_progress_uses_derived_remaining_hours():
+    data = curriculum_to_dict(_curriculum())
+
+    assert data["progress"][0] == {
+        "description": "Total",
+        "completed_hours": 120,
+        "total_hours": 300,
+        "remaining_hours": 180,
+        "completed_percent": 40.0,
+    }

--- a/tests/test_mcp_curriculum.py
+++ b/tests/test_mcp_curriculum.py
@@ -1,0 +1,124 @@
+from dataclasses import replace
+from decimal import Decimal
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from sigaa import mcp_server
+from sigaa.parsers.curriculum import CurriculumDataError, parse_curriculum
+from sigaa.parsers.transcript import CraUnavailableError
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "curriculum.json"
+
+
+def _curriculum():
+    return replace(
+        parse_curriculum(FIXTURE.read_text(encoding="utf-8")),
+        cra=Decimal("8.42"),
+        cra_source="academic_transcript",
+    )
+
+
+def _configured_settings():
+    return SimpleNamespace(
+        username="configured-user",
+        resolve_password=lambda: "test-password",
+    )
+
+
+def test_mcp_registers_curriculum_and_cra_tools():
+    names = set(mcp_server.mcp._tool_manager._tools)
+
+    assert {"sigaa_get_curriculum", "sigaa_get_cra"} <= names
+
+
+def test_mcp_curriculum_uses_shared_contract_and_filters(monkeypatch):
+    class FakeClient:
+        def __init__(self, username, password):
+            assert (username, password) == ("configured-user", "test-password")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_curriculum_status(self, *, include_cra):
+            assert include_cra is True
+            return _curriculum()
+
+    monkeypatch.setattr(mcp_server, "Settings", _configured_settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+
+    data = mcp_server.sigaa_get_curriculum(
+        status="pending",
+        required_only=True,
+        period=2,
+        include_requirements=True,
+    )
+
+    assert data["cra"] == {"value": 8.42, "source": "academic_transcript"}
+    assert [component["code"] for component in data["components"]] == ["SYN0003"]
+    assert data["components"][0]["prerequisite"] == "( SYN0001 )"
+    assert "idDiscente" not in json.dumps(data)
+
+
+def test_mcp_cra_treats_missing_value_as_valid_state(monkeypatch):
+    class FakeClient:
+        def __init__(self, username, password):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_cra(self):
+            raise CraUnavailableError("CRA is not available in transcript")
+
+    monkeypatch.setattr(mcp_server, "Settings", _configured_settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+
+    assert mcp_server.sigaa_get_cra() == {
+        "value": None,
+        "source": "unavailable",
+    }
+
+
+def test_mcp_curriculum_errors_are_sanitized(monkeypatch):
+    class FakeClient:
+        def __init__(self, username, password):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_curriculum_status(self, *, include_cra):
+            raise CurriculumDataError("Invalid curriculum response")
+
+    monkeypatch.setattr(mcp_server, "Settings", _configured_settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+
+    with pytest.raises(ToolError, match="Invalid curriculum response") as exc_info:
+        mcp_server.sigaa_get_curriculum()
+
+    assert "private" not in str(exc_info.value).lower()
+
+
+def test_mcp_curriculum_requires_credentials(monkeypatch):
+    settings = SimpleNamespace(username=None, resolve_password=lambda: None)
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+
+    with pytest.raises(ToolError, match="no credentials"):
+        mcp_server.sigaa_get_curriculum()

--- a/tests/test_mcp_curriculum_protocol.py
+++ b/tests/test_mcp_curriculum_protocol.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def test_mcp_stdio_exposes_curriculum_schemas_and_tool_errors():
+    async def exercise_server():
+        environment = dict(os.environ)
+        environment.pop("SIGAA_USER", None)
+        environment.pop("SIGAA_PASS", None)
+        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "sigaa.mcp_server"],
+            env=environment,
+        )
+
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                tools = {tool.name: tool for tool in listed.tools}
+
+                assert {"sigaa_get_curriculum", "sigaa_get_cra"} <= set(tools)
+                curriculum = tools["sigaa_get_curriculum"]
+                properties = curriculum.inputSchema["properties"]
+                assert set(properties) == {
+                    "status",
+                    "required_only",
+                    "period",
+                    "include_requirements",
+                    "include_cra",
+                }
+                assert properties["status"]["default"] == "current"
+                assert properties["status"]["enum"] == [
+                    "current",
+                    "enrolled",
+                    "pending",
+                    "completed",
+                    "all",
+                ]
+
+                rejected = await session.call_tool("sigaa_get_curriculum", {})
+                assert rejected.isError is True
+                assert "no credentials available" in " ".join(
+                    getattr(item, "text", "") for item in rejected.content
+                )
+
+                invalid = await session.call_tool(
+                    "sigaa_get_curriculum",
+                    {"status": "not-a-status"},
+                )
+                assert invalid.isError is True
+
+    asyncio.run(exercise_server())

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -17,6 +17,7 @@ def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
         environment = dict(os.environ)
         environment.pop("SIGAA_USER", None)
         environment.pop("SIGAA_PASS", None)
+        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
         environment["SIGAA_DOWNLOAD_DIR"] = str(tmp_path)
         parameters = StdioServerParameters(
             command=sys.executable,

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,12 +1,60 @@
 import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
+from sigaa import setup_wizard
+from sigaa.config import KEYRING_ACTIVE_USERNAME, KEYRING_SERVICE, Settings
 from sigaa.setup_wizard import (
     build_cron_line,
     build_launchd_plist,
     merge_mcp_config,
     resolve_script,
 )
+
+
+def test_login_persists_username_for_the_next_process(monkeypatch):
+    credentials: dict[tuple[str, str], str] = {}
+    events: list[str] = []
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert (username, password) == ("alice", "test-password")
+
+        def __enter__(self):
+            events.append("verified")
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_student(self):
+            return SimpleNamespace(name="ALICE", matricula="00000000000")
+
+    def set_password(service, username, password):
+        events.append(f"stored:{username}")
+        credentials[(service, username)] = password
+
+    fake_keyring = SimpleNamespace(
+        set_password=set_password,
+        get_password=lambda service, username: credentials.get((service, username)),
+    )
+    monkeypatch.setitem(sys.modules, "keyring", fake_keyring)
+    monkeypatch.setattr(setup_wizard, "SigaaClient", FakeClient)
+    monkeypatch.delenv("SIGAA_USER", raising=False)
+    monkeypatch.delenv("SIGAA_PASS", raising=False)
+
+    setup_wizard.verify_and_store_login("alice", "test-password")
+    fresh_settings = Settings()
+
+    assert credentials[(KEYRING_SERVICE, KEYRING_ACTIVE_USERNAME)] == "alice"
+    assert fresh_settings.username == "alice"
+    assert fresh_settings.resolve_password() == "test-password"
+    assert events == [
+        "verified",
+        "stored:alice",
+        f"stored:{KEYRING_ACTIVE_USERNAME}",
+    ]
 
 
 def test_merge_mcp_config_preserves_existing_servers(tmp_path):

--- a/tests/test_transcript_parser.py
+++ b/tests/test_transcript_parser.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from sigaa.parsers.transcript import (
+    CraUnavailableError,
+    TranscriptParseError,
+    parse_cra_pdf,
+    parse_cra_text,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("Coeficiente de Rendimento Acadêmico (CRA): 8,76", "8.76"),
+        ("CRA = 7.50", "7.50"),
+        ("Índices acadêmicos\nCRA\n8,42\nFim", "8.42"),
+        ("Índices acadêmicos\nCRA\nObservação\nValor: 9,10", "9.10"),
+        ("8.25\nCRA", "8.25"),
+        ("cra: 0,00", "0.00"),
+        ("CRA: 10.00", "10.00"),
+        ("CRA      MC\n8.61     7.20", "8.61"),
+    ],
+)
+def test_parse_cra_text_handles_common_pdf_layouts(text, expected):
+    assert parse_cra_text(text) == Decimal(expected)
+
+
+def test_parse_cra_text_accepts_repeated_matching_value():
+    text = "Resumo\nCRA: 8,40\nDetalhamento\nCRA\n8.40"
+
+    assert parse_cra_text(text) == Decimal("8.40")
+
+
+def test_boxed_cra_below_label_wins_over_period_number_above():
+    text = f"{' ' * 7}9\nCRA:\n{' ' * 27}6.54"
+
+    assert parse_cra_text(text) == Decimal("6.54")
+
+
+def test_explicit_cra_label_without_value_does_not_fall_back_up():
+    text = f"{' ' * 7}9\nCRA:\n"
+
+    with pytest.raises(CraUnavailableError):
+        parse_cra_text(text)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "CRA      MC\n         7.20",
+        "MC      CRA\n7.20",
+    ],
+)
+def test_empty_cra_table_cell_does_not_use_neighboring_index(text):
+    with pytest.raises(CraUnavailableError):
+        parse_cra_text(text)
+
+
+@pytest.mark.parametrize("text", ["Average result: 8.75", "CRA without value"])
+def test_missing_cra_is_a_valid_unavailable_state(text):
+    with pytest.raises(CraUnavailableError):
+        parse_cra_text(text)
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        ("CRA: 10,01", "supported range"),
+        ("CRA: 8,50\nResumo\nCRA: 8,75", "conflicting"),
+    ],
+)
+def test_parse_cra_text_rejects_missing_invalid_or_conflicting_values(text, message):
+    with pytest.raises(TranscriptParseError, match=message):
+        parse_cra_text(text)
+
+
+def test_parse_errors_never_echo_private_transcript_text():
+    private_text = "CRA sem valor - estudante PRIVATE-STUDENT-ID"
+
+    with pytest.raises(TranscriptParseError) as exc_info:
+        parse_cra_text(private_text)
+
+    assert "PRIVATE-STUDENT-ID" not in str(exc_info.value)
+
+
+def test_parse_cra_pdf_extracts_text_from_in_memory_pdf():
+    content = _synthetic_text_pdf(["HISTORICO ACADEMICO", "CRA: 8.73"])
+
+    assert parse_cra_pdf(content) == Decimal("8.73")
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        b"PRIVATE-PDF-CONTENT",
+        b"%PDF-1.7\nPRIVATE-MALFORMED-CONTENT",
+    ],
+)
+def test_parse_cra_pdf_rejects_invalid_content_with_sanitized_error(content):
+    with pytest.raises(TranscriptParseError) as exc_info:
+        parse_cra_pdf(content)
+
+    assert "PRIVATE" not in str(exc_info.value)
+    assert content.decode("ascii") not in str(exc_info.value)
+
+
+def _synthetic_text_pdf(lines: list[str]) -> bytes:
+    """Build a tiny offline PDF with extractable ASCII text."""
+
+    text_operations = ["BT", "/F1 12 Tf", "72 720 Td"]
+    for index, line in enumerate(lines):
+        if index:
+            text_operations.append("0 -18 Td")
+        escaped = line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        text_operations.append(f"({escaped}) Tj")
+    text_operations.append("ET")
+    stream = "\n".join(text_operations).encode("ascii")
+
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        (
+            f"<< /Length {len(stream)} >>\nstream\n".encode("ascii")
+            + stream
+            + b"\nendstream"
+        ),
+    ]
+
+    document = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for object_number, body in enumerate(objects, start=1):
+        offsets.append(len(document))
+        document.extend(f"{object_number} 0 obj\n".encode("ascii"))
+        document.extend(body)
+        document.extend(b"\nendobj\n")
+
+    xref_offset = len(document)
+    document.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    document.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        document.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    document.extend(
+        (
+            f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+            f"startxref\n{xref_offset}\n%%EOF\n"
+        ).encode("ascii")
+    )
+    return bytes(document)


### PR DESCRIPTION
## What changed

- add live curriculum integration parsing and normalized models for completed, enrolled, pending, optional, and required components
- expose CRA and curriculum progress through the Python client, CLI, and MCP with shared filters and a consistent JSON contract
- persist the active keyring username so network commands work after `sigaa login`
- document the CLI/MCP workflows and isolate protocol tests from real keyring credentials

## Why

SIGAA's curriculum JSON contains integration progress and components, but no CRA. The CRA is read from the official academic transcript in memory. The parser associates the explicit CRA field with its boxed value and does not fall back to unrelated values above it.

## User impact

- `sigaa curriculum` shows enrolled and required pending components with workload progress
- `sigaa cra` returns the official transcript CRA
- optional pending components remain clearly identified as choices, not courses that must all be completed
- human output omits the opaque curriculum identifier; JSON retains it for agents
- `--no-cra` / `include_cra=false` skips the extra transcript request

## Validation

- `python -m pytest -q --deselect tests/test_setup_wizard.py::test_resolve_script_falls_back_to_current_python_dir` — 154 passed, 1 deselected
- focused CLI/client/parser/MCP tests — 38 passed
- `python -m compileall -q sigaa tests`
- `git diff --check`
- sensitive-pattern scan of the staged patch
- sanitized live smoke test confirmed that the parser selects the boxed CRA field rather than the academic-period number and that responses omit `idDiscente`

Known baseline: the full Windows suite still has the pre-existing Unix-path expectation failure in `test_resolve_script_falls_back_to_current_python_dir`.