### PR TITLE
Add public SIPAC process lookup and search

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ SIGAA username or password.
 
 ## Public SIPAC process lookup
 
-Use this feature to follow UFPB administrative processes without opening each SIPAC page manually. It returns the current status, subject, interested parties, public documents, routing movements, status changes, and attached files.
+Use this feature to follow UFPB administrative processes without opening each SIPAC page manually. Look up one process by its complete number or find processes by an interested party name or identifier. Process details include the current status, subject, interested parties, public documents, routing movements, status changes, and attached files.
 
 ```bash
 sigaa sipac process 23074.056437/2026-26
 sigaa sipac process 23074.056437/2026-26 --json
+sigaa sipac search --name "Gilberto Farias de Sousa Filho"
+sigaa sipac search --identifier "12345678901" --page 2 --json
 ```
 
 Example summary:
@@ -61,7 +63,7 @@ Example summary:
   Interested parties: 1 | Documents: 14 | Movements: 6
 ```
 
-Agents can call `sipac_get_public_process` with `{"number": "23074.056437/2026-26"}` and receive the same `schema_version: 1` contract as the CLI JSON output. The lookup does not authenticate, bypass restricted documents, change processes, or persist results. See the [SIPAC process guide](docs/sipac-processes.mdx) for fields, use cases, and error handling.
+Agents can call `sipac_get_public_process` with `{"number": "23074.056437/2026-26"}`. To search, call `sipac_search_public_processes` with either `name` or `identifier`. Both interfaces use the same `schema_version: 1` contracts as the CLI JSON output. Public SIPAC commands do not authenticate, bypass restricted documents, change processes, or persist results. See the [SIPAC process guide](docs/sipac-processes.mdx) for fields, use cases, privacy guidance, and error handling.
 
 Headless fallback: `export SIGAA_USER=... SIGAA_PASS=...`.
 Optional `SIGAA_DB=/path/to/sigaa.db` to override the store location.
@@ -80,6 +82,7 @@ sigaa ics --out sigaa.ics  # export classes + deadlines as a calendar
 sigaa curriculum           # live CRA, enrolled + required pending components
 sigaa cra --json           # official CRA as JSON from the academic transcript
 sigaa sipac process 23074.056437/2026-26 --json # public SIPAC process lookup
+sigaa sipac search --name "Gilberto Farias de Sousa Filho" --json # find public processes
 sigaa historico --out h.pdf # download the academic transcript PDF (networked)
 sigaa declaracao-vinculo --out declaracao-vinculo.pdf # enrollment declaration PDF (networked)
 sigaa atestado-matricula --out atestado-matricula.html # enrollment certificate HTML (networked)
@@ -98,7 +101,7 @@ server without manual absolute-path editing.
 Tools: `sigaa_list_classes`, `sigaa_list_news`, `sigaa_get_news_body`,
 `sigaa_get_schedule`, `sigaa_list_grades`, `sigaa_list_deadlines`,
 `sigaa_get_curriculum`, `sigaa_get_cra`, `sigaa_export_ics`,
-`sipac_get_public_process`,
+`sipac_get_public_process`, `sipac_search_public_processes`,
 `sigaa_download_historico`,
 `sigaa_download_declaracao_vinculo`, `sigaa_download_atestado_matricula`,
 `sigaa_sync`. Store-backed reads are offline; sync, live lookups, and downloads
@@ -108,6 +111,14 @@ touch the network.
 by UFPB: general data, interested parties, documents and public download links,
 movements, status changes, and attached files. It shares schema version 1 with
 `sigaa sipac process --json` and does not require credentials.
+
+`sipac_search_public_processes(name?, identifier?, page=1)` finds public
+processes by one interested-party field. Pass exactly one of `name` or
+`identifier`. Each response contains at most the 15 results exposed by one
+portal page. Number and name results use a short in-memory cache; identifier
+searches are never cached.
+Identifiers such as CPF, registration number, and CNPJ are personal data. Query
+them only for a legitimate purpose and avoid copying them into logs.
 
 `sigaa_get_curriculum` is networked and uses the same normalized contract and
 filters as `sigaa curriculum`: `status`, `required_only`, `period`,

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ movements, status changes, and attached files. It shares schema version 1 with
 `sipac_search_public_processes(name?, identifier?, page=1)` finds public
 processes by one interested-party field. Pass exactly one of `name` or
 `identifier`. Each response contains at most the 15 results exposed by one
-portal page. Number and name results use a short in-memory cache; identifier
-searches are never cached.
+portal page. Results are not retained after the request finishes.
 Identifiers such as CPF, registration number, and CNPJ are personal data. Query
 them only for a legitimate purpose and avoid copying them into logs.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ sync, and can configure MCP and scheduled polling for you.
 Public SIPAC process queries do not need credentials and never read the stored
 SIGAA username or password.
 
+## Public SIPAC process lookup
+
+Use this feature to follow UFPB administrative processes without opening each SIPAC page manually. It returns the current status, subject, interested parties, public documents, routing movements, status changes, and attached files.
+
+```bash
+sigaa sipac process 23074.056437/2026-26
+sigaa sipac process 23074.056437/2026-26 --json
+```
+
+Example summary:
+
+```text
+23074.056437/2026-26  [ATIVO]
+  ANÁLISE DE PROPOSTA DE RESOLUÇÃO SOBRE DISTRIBUIÇÃO DE ENCARGOS DIDÁTICOS
+  Origin: CI - DIREÇÃO DE CENTRO (11.01.45.01)
+  Opened: 12/06/2026 17:26
+  Interested parties: 1 | Documents: 14 | Movements: 6
+```
+
+Agents can call `sipac_get_public_process` with `{"number": "23074.056437/2026-26"}` and receive the same `schema_version: 1` contract as the CLI JSON output. The lookup does not authenticate, bypass restricted documents, change processes, or persist results. See the [SIPAC process guide](docs/sipac-processes.mdx) for fields, use cases, and error handling.
+
 Headless fallback: `export SIGAA_USER=... SIGAA_PASS=...`.
 Optional `SIGAA_DB=/path/to/sigaa.db` to override the store location.
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 > [!IMPORTANT]
 > This is an unofficial personal project and is not affiliated with, endorsed
-> by, or supported by UFPB or SIGAA. Use it responsibly, keep request rates low,
+> by, or supported by UFPB, SIGAA, or SIPAC. Use it responsibly, keep request rates low,
 > and follow the rules that apply to your SIGAA account.
 
-User-friendly client for **SIGAA UFPB** (sigaa.ufpb.br) built for automation:
-a **CLI** and an **MCP server** over a layered Python core. Scope: single user.
+User-friendly client for **SIGAA UFPB** and the **SIPAC/UFPB public process
+portal**, built for automation: a **CLI** and an **MCP server** over a layered
+Python core. Authenticated SIGAA features remain single-user and local-first.
 
 SIGAA has no official API. This wraps the JSF web flow: login (cookie jar +
 `ViewState`, no JWT, no CAPTCHA), enrolled classes, academic progress and CRA,
@@ -32,13 +33,14 @@ sigaa init
 ## Credentials
 
 Keyring-first, env-second. Never commit credentials, cookies, downloaded live
-HTML, SQLite databases, exported PDFs, or `.env` files. Recommended
-=======
+HTML, SQLite databases, exported PDFs, or `.env` files.
 
 Run `sigaa init`. It prompts for your SIGAA username and password, stores the
 password in your OS keyring when available, verifies the login, runs the first
 sync, and can configure MCP and scheduled polling for you.
->>>>>>> 86efdfc5c737216768d4fbd4fc659a3e74ec6b93
+
+Public SIPAC process queries do not need credentials and never read the stored
+SIGAA username or password.
 
 Headless fallback: `export SIGAA_USER=... SIGAA_PASS=...`.
 Optional `SIGAA_DB=/path/to/sigaa.db` to override the store location.
@@ -56,6 +58,7 @@ sigaa deadlines            # assessment/task due dates
 sigaa ics --out sigaa.ics  # export classes + deadlines as a calendar
 sigaa curriculum           # live CRA, enrolled + required pending components
 sigaa cra --json           # official CRA as JSON from the academic transcript
+sigaa sipac process 23074.056437/2026-26 --json # public SIPAC process lookup
 sigaa historico --out h.pdf # download the academic transcript PDF (networked)
 sigaa declaracao-vinculo --out declaracao-vinculo.pdf # enrollment declaration PDF (networked)
 sigaa atestado-matricula --out atestado-matricula.html # enrollment certificate HTML (networked)
@@ -63,7 +66,8 @@ sigaa watch --interval 900 # foreground loop
 ```
 
 Store-backed listing commands are fast and offline. Login, sync/watch, live
-lookups, and downloads access SIGAA over the network.
+lookups, and downloads access the network. `sigaa sipac process` reads only
+SIPAC's public portal and does not authenticate.
 
 ## MCP server (for code agents)
 
@@ -73,10 +77,16 @@ server without manual absolute-path editing.
 Tools: `sigaa_list_classes`, `sigaa_list_news`, `sigaa_get_news_body`,
 `sigaa_get_schedule`, `sigaa_list_grades`, `sigaa_list_deadlines`,
 `sigaa_get_curriculum`, `sigaa_get_cra`, `sigaa_export_ics`,
+`sipac_get_public_process`,
 `sigaa_download_historico`,
 `sigaa_download_declaracao_vinculo`, `sigaa_download_atestado_matricula`,
 `sigaa_sync`. Store-backed reads are offline; sync, live lookups, and downloads
 touch the network.
+
+`sipac_get_public_process(number)` returns the public process metadata exposed
+by UFPB: general data, interested parties, documents and public download links,
+movements, status changes, and attached files. It shares schema version 1 with
+`sigaa sipac process --json` and does not require credentials.
 
 `sigaa_get_curriculum` is networked and uses the same normalized contract and
 filters as `sigaa curriculum`: `status`, `required_only`, `period`,
@@ -167,8 +177,9 @@ sigaa/
   http.py       session: cookie jar, ViewState, re-login + retry
   auth.py       login flow
   client.py     SigaaClient -> domain models
+  sipac.py      unauthenticated public SIPAC process client + JSON contract
   models.py     Student, Turma, NewsItem, Schedule, CurriculumStatus
-  parsers/      portal, news, schedule, curriculum, transcript
+  parsers/      portal, news, schedule, curriculum, transcript, SIPAC process
   store/        SQLite db + repository (dedup, queries)
   services/     sync (fetch -> diff -> persist)
   cli.py        command line
@@ -179,6 +190,7 @@ Adding a feature (materials, attendance) = a parser + client method and a
 CLI/MCP surface, plus store columns when it is persisted. HTML changes touch
 only `parsers/`. Implemented so far: classes, news (+bodies), grades, deadlines,
 curriculum progress, official CRA, academic documents, and ICS export.
+Public SIPAC administrative-process consultation is also available live.
 
 `exporters/` turns store data into interchange formats (currently `ics`).
 
@@ -200,6 +212,9 @@ Single-user, local-first tool. `config.py` reads credentials from keyring first
 and environment variables second. The SQLite db is local and may contain student
 data copied from SIGAA. `.gitignore` excludes `*.db`, `.env`, and live HTML
 dumps, but review generated files before sharing logs, issues, or screenshots.
+The SIPAC process feature is read-only and public; it does not send stored
+credentials, but its responses can contain names and identifiers already shown
+by the public portal, so handle exported JSON responsibly.
 
 ## License
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -20,7 +20,7 @@ sigaa [--user seu_usuario] [--db caminho_do_banco] comando [opções]
 | `--db` | sobrescreve o caminho do SQLite (senão usa `SIGAA_DB` ou o padrão) |
 
 <Note>
-`login`, `sync`, `watch`, `curriculum`, `cra`, `sipac process`, `historico`,
+`login`, `sync`, `watch`, `curriculum`, `cra`, `sipac process`, `sipac search`, `historico`,
 `declaracao-vinculo`, `atestado-matricula`, `attendance`, `plan` e o download
 de materiais acessam a **rede**. Os demais comandos leem do **banco local**.
 Quase todo comando de leitura aceita `--json`.
@@ -65,7 +65,7 @@ sigaa sipac search --name "Gilberto Farias de Sousa Filho"
 sigaa sipac search --identifier "12345678901" --page 2 --json
 ```
 
-Cada página retorna no máximo os 15 resultados exibidos pelo portal. Consultas por número e nome usam um cache curto somente em memória; consultas por identificador nunca entram no cache.
+Cada página retorna no máximo os 15 resultados exibidos pelo portal. Os resultados não são armazenados depois que o comando termina.
 
 | Flag | Descrição |
 |---|---|

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -56,6 +56,28 @@ públicos, movimentações, alterações de status e anexos quando disponíveis.
 |---|---|
 | `--json` | retorna o contrato completo em JSON |
 
+### `sipac search`
+
+Busca processos públicos pelo nome ou identificador de uma parte interessada. Passe exatamente uma opção: `--name` ou `--identifier`.
+
+```bash
+sigaa sipac search --name "Gilberto Farias de Sousa Filho"
+sigaa sipac search --identifier "12345678901" --page 2 --json
+```
+
+Cada página retorna no máximo os 15 resultados exibidos pelo portal. Consultas por número e nome usam um cache curto somente em memória; consultas por identificador nunca entram no cache.
+
+| Flag | Descrição |
+|---|---|
+| `--name nome` | busca pelo nome da parte interessada |
+| `--identifier identificador` | busca por CPF, matrícula, CNPJ ou outro identificador aceito pelo portal |
+| `--page número` | seleciona a página de resultados, começando em `1` |
+| `--json` | retorna resultados e paginação em JSON |
+
+<Warning>
+CPF, matrícula e CNPJ são dados pessoais. Use `--identifier` somente para uma finalidade legítima e evite registrar ou compartilhar o valor consultado.
+</Warning>
+
 ## Atualizar (networked)
 
 ### `sync`

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -15,7 +15,7 @@ sigaa [--user USUARIO] [--db CAMINHO] <comando> [opções]
 | `--db` | sobrescreve o caminho do SQLite (senão usa `SIGAA_DB` ou o padrão) |
 
 <Note>
-`login`, `sync`, `watch`, `curriculum`, `cra`, `historico`,
+`login`, `sync`, `watch`, `curriculum`, `cra`, `sipac process`, `historico`,
 `declaracao-vinculo`, `atestado-matricula`, `attendance`, `plan` e o download
 de materiais acessam a **rede**. Os demais comandos leem do **banco local**.
 Quase todo comando de leitura aceita `--json`.
@@ -30,6 +30,26 @@ Pede a senha, guarda no keychain e valida no SIGAA. **Networked.**
 ```bash
 sigaa --user SEU_USUARIO login
 ```
+
+## SIPAC público (networked, sem login)
+
+### `sipac process`
+
+Consulta um processo administrativo pelo número completo no Portal Público do
+SIPAC/UFPB. O comando não usa as credenciais armazenadas do SIGAA ou SIPAC.
+
+```bash
+sigaa sipac process 23074.056437/2026-26
+sigaa sipac process 23074.056437/2026-26 --json
+```
+
+A saída JSON usa o mesmo contrato `schema_version: 1` da tool MCP
+`sipac_get_public_process` e inclui dados gerais, interessados, documentos
+públicos, movimentações, alterações de status e anexos quando disponíveis.
+
+| Flag | Descrição |
+|---|---|
+| `--json` | retorna o contrato completo em JSON |
 
 ## Atualizar (networked)
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,12 +1,17 @@
 ---
-title: "Referência do CLI"
+title: "Usar os comandos do CLI"
 description: "Todos os comandos do sigaa, suas flags e o que cada um faz."
+meta:
+  contentType: "Reference"
+  category: "Referência"
 ---
+
+Use esta página para localizar comandos, opções e formatos de saída do CLI.
 
 Uso geral:
 
 ```bash
-sigaa [--user USUARIO] [--db CAMINHO] <comando> [opções]
+sigaa [--user seu_usuario] [--db caminho_do_banco] comando [opções]
 ```
 
 | Flag global | Descrição |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,7 +11,7 @@
     "groups": [
       {
         "group": "Começando",
-        "pages": ["introduction", "getting-started"]
+        "pages": ["introduction", "getting-started", "sipac-processes"]
       },
       {
         "group": "Referência",

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,12 +1,17 @@
 ---
-title: "Primeiros passos"
+title: "Começar a usar o sigaa-ai-agent"
 description: "Instale o sigaa-ai-agent, faça login e rode o primeiro sync."
+meta:
+  contentType: "Tutorial"
+  category: "Começando"
 ---
+
+Instale o projeto, configure os recursos acadêmicos e faça sua primeira consulta. Você pode consultar processos públicos do SIPAC sem uma conta.
 
 ## Pré-requisitos
 
 - **Python 3.11+**
-- Uma conta no **SIGAA UFPB**
+- Uma conta no **SIGAA UFPB** para recursos acadêmicos autenticados. A consulta pública do SIPAC não exige conta
 
 ## 1. Instalar
 
@@ -109,13 +114,13 @@ Sua resposta segue o mesmo contrato JSON do CLI e não expõe `idDiscente`.
 
 ## 6. Consultar um processo público do SIPAC
 
-Essa consulta é pública e não usa a senha armazenada:
+Essa consulta retorna assunto, situação, documentos e movimentações sem usar a senha armazenada:
 
 ```bash
 sigaa sipac process 23074.056437/2026-26 --json
 ```
 
-No MCP, use `sipac_get_public_process` com o mesmo número completo.
+No MCP, use `sipac_get_public_process` com o mesmo número completo. Consulte [Consultar processos públicos do SIPAC](/sipac-processes) para ver exemplos, campos e limites.
 
 <Tip>
 Rode `sigaa sync` de tempos em tempos (ou deixe `sigaa watch` rodando) pra manter o

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -107,6 +107,16 @@ As mesmas consultas estão disponíveis no MCP como `sigaa_get_curriculum` e
 equivalentes `required_only`, `period`, `include_requirements` e `include_cra`.
 Sua resposta segue o mesmo contrato JSON do CLI e não expõe `idDiscente`.
 
+## 6. Consultar um processo público do SIPAC
+
+Essa consulta é pública e não usa a senha armazenada:
+
+```bash
+sigaa sipac process 23074.056437/2026-26 --json
+```
+
+No MCP, use `sipac_get_public_process` com o mesmo número completo.
+
 <Tip>
 Rode `sigaa sync` de tempos em tempos (ou deixe `sigaa watch` rodando) pra manter o
 banco atualizado. Veja todos os comandos na [Referência do CLI](/cli).

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -114,13 +114,19 @@ Sua resposta segue o mesmo contrato JSON do CLI e não expõe `idDiscente`.
 
 ## 6. Consultar um processo público do SIPAC
 
-Essa consulta retorna assunto, situação, documentos e movimentações sem usar a senha armazenada:
+Consulte um processo pelo número completo sem usar a senha armazenada:
 
 ```bash
 sigaa sipac process 23074.056437/2026-26 --json
 ```
 
-No MCP, use `sipac_get_public_process` com o mesmo número completo. Consulte [Consultar processos públicos do SIPAC](/sipac-processes) para ver exemplos, campos e limites.
+Você também pode encontrar processos pelo nome de uma parte interessada:
+
+```bash
+sigaa sipac search --name "Gilberto Farias de Sousa Filho" --json
+```
+
+No MCP, use `sipac_get_public_process` para consultar pelo número ou `sipac_search_public_processes` para buscar por nome ou identificador. Consulte [Consultar processos públicos do SIPAC](/sipac-processes) para ver exemplos, campos, privacidade e limites.
 
 <Tip>
 Rode `sigaa sync` de tempos em tempos (ou deixe `sigaa watch` rodando) pra manter o

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -28,6 +28,8 @@ sync/watch, consultas ao vivo e downloads acessam o SIGAA pela rede.
 
 ## O que dá pra fazer hoje
 
+- Consultar **processos administrativos públicos do SIPAC/UFPB** pelo número,
+  sem login, pelo CLI ou MCP
 - Listar turmas e o **horário** decodificado da semana
 - Ver **notícias**, **notas** (gerais e por turma), **prazos** e **frequência**
 - Ver o **CRA oficial**, os componentes matriculados e o que falta para integralizar

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,14 +1,12 @@
 ---
-title: "Introdução"
+title: "Entender o sigaa-ai-agent"
 description: "O que é o sigaa-ai-agent e como ele funciona."
+meta:
+  contentType: "Conceptual"
+  category: "Começando"
 ---
 
-O **sigaa-ai-agent** é um cliente do **SIGAA UFPB** feito para automação: um
-**CLI** e um **servidor MCP** sobre um núcleo Python em camadas. Como o SIGAA não
-tem API oficial, ele entra pelo fluxo web (login com cookie + `ViewState`) e
-busca suas **turmas, notícias, notas, faltas, prazos, plano de curso, materiais,
-CRA e integralização curricular**. Os dados sincronizados ficam num **SQLite
-local**; CRA e currículo são consultas ao vivo.
+O **sigaa-ai-agent** conecta agentes e scripts aos sistemas SIGAA e SIPAC da UFPB por um CLI e um servidor MCP. As funções acadêmicas usam sua sessão local do SIGAA, enquanto a consulta de processos administrativos lê somente o Portal Público do SIPAC.
 
 <Note>
 As listagens armazenadas no SQLite são rápidas e funcionam offline. Login,
@@ -24,12 +22,14 @@ sync/watch, consultas ao vivo e downloads acessam o SIGAA pela rede.
   <Card title="Referência do CLI" icon="terminal" href="/cli">
     Todos os comandos, flags e o que cada um faz.
   </Card>
+  <Card title="Processos públicos do SIPAC" icon="magnifying-glass" href="/sipac-processes">
+    Consulte assunto, situação, documentos e movimentações sem login.
+  </Card>
 </CardGroup>
 
 ## O que dá pra fazer hoje
 
-- Consultar **processos administrativos públicos do SIPAC/UFPB** pelo número,
-  sem login, pelo CLI ou MCP
+- Consultar processos administrativos públicos do SIPAC/UFPB pelo número, sem login, pelo CLI ou MCP
 - Listar turmas e o **horário** decodificado da semana
 - Ver **notícias**, **notas** (gerais e por turma), **prazos** e **frequência**
 - Ver o **CRA oficial**, os componentes matriculados e o que falta para integralizar

--- a/docs/sipac-processes.mdx
+++ b/docs/sipac-processes.mdx
@@ -6,13 +6,14 @@ meta:
   category: "Começando"
 ---
 
-Use a consulta pública do Sistema Integrado de Patrimônio, Administração e Contratos (SIPAC) para transformar um número de processo da Universidade Federal da Paraíba (UFPB) em dados estruturados. A consulta funciona sem login pela interface de linha de comando (CLI) e pelo Model Context Protocol (MCP).
+Use a consulta pública do Sistema Integrado de Patrimônio, Administração e Contratos (SIPAC) para encontrar processos da Universidade Federal da Paraíba (UFPB) e ler seus dados estruturados. Consulte pelo número completo ou busque pelo nome ou identificador de uma parte interessada. As duas modalidades funcionam sem login pela interface de linha de comando (CLI) e pelo Model Context Protocol (MCP).
 
 ## Para que serve
 
 A integração elimina a consulta manual no portal quando você precisa acompanhar ou analisar processos administrativos. Você pode:
 
 - Confirmar o assunto, a situação e a unidade de origem
+- Encontrar processos relacionados a uma pessoa ou organização
 - Identificar por quais unidades o processo passou
 - Ver quem enviou e recebeu cada movimentação
 - Listar documentos e abrir os arquivos que o portal marcou como públicos
@@ -57,6 +58,45 @@ Chame `sipac_get_public_process` com o mesmo número completo:
 
 A tool não lê o usuário ou a senha configurados para o SIGAA. Ela consulta somente o Portal Público do SIPAC.
 
+## Buscar por parte interessada
+
+Use `sipac search` quando você não souber o número do processo. Passe exatamente um critério por consulta: nome ou identificador.
+
+Busque pelo nome:
+
+```bash
+sigaa sipac search --name "Gilberto Farias de Sousa Filho"
+```
+
+Busque por um identificador aceito pelo portal:
+
+```bash
+sigaa sipac search --identifier "12345678901" --json
+```
+
+O identificador pode ser um Cadastro de Pessoas Físicas (CPF), uma matrícula, um Cadastro Nacional da Pessoa Jurídica (CNPJ) ou outro valor aceito pelo SIPAC. O comando rejeita consultas sem critério ou com `--name` e `--identifier` juntos.
+
+Use `--page` para continuar a busca. A primeira página é `1`, e cada página contém no máximo os 15 resultados exibidos pelo portal:
+
+```bash
+sigaa sipac search --name "Gilberto Farias de Sousa Filho" --page 2 --json
+```
+
+No MCP, chame `sipac_search_public_processes` com o mesmo critério:
+
+```json
+{
+  "name": "Gilberto Farias de Sousa Filho",
+  "page": 1
+}
+```
+
+Você também pode passar `identifier` no lugar de `name`. Passe apenas um deles. A tool retorna os resultados da página solicitada e os metadados necessários para decidir se existe outra página.
+
+<Warning>
+CPF, matrícula e CNPJ são dados pessoais. Pesquise um identificador somente para uma finalidade legítima. Não inclua o valor em logs, issues, exemplos públicos ou mensagens compartilhadas sem necessidade.
+</Warning>
+
 ## Entender a resposta
 
 O CLI com `--json` e a tool MCP retornam o mesmo contrato `schema_version: 1`:
@@ -85,6 +125,8 @@ A integração respeita as mesmas permissões do Portal Público do SIPAC:
 - Não contorna documentos restritos ou negados
 - Não altera, movimenta ou protocola processos
 - Não armazena os resultados em banco local
+- Mantém um cache curto, somente em memória, para consultas por número e nome; buscas por identificador nunca entram no cache
+- Limita cada resposta de busca aos 15 resultados da página retornada pelo portal
 - Depende da disponibilidade e do HTML atual do portal da UFPB
 
 As respostas podem conter nomes e identificadores que o próprio portal publicou. Trate arquivos JSON, logs e documentos baixados como dados administrativos potencialmente sensíveis.
@@ -96,5 +138,7 @@ Use a mensagem de erro para distinguir um número inválido de uma falha no port
 `invalid SIPAC process number` indica que o número não segue o formato `00000.000000/0000-00`. Confira pontos, barra, hífen e dígitos verificadores.
 
 `SIPAC process 23074.056437/2026-26 was not found` indica que o portal não retornou uma correspondência exata. Confirme o número na consulta pública da UFPB.
+
+Uma busca sem `--name` ou `--identifier`, ou com as duas opções, é inválida. Escolha somente um critério e tente novamente.
 
 Erros de rede ou de leitura podem indicar indisponibilidade ou mudança no portal. Tente novamente mais tarde e abra uma issue se o erro persistir para processos que o navegador encontra.

--- a/docs/sipac-processes.mdx
+++ b/docs/sipac-processes.mdx
@@ -1,0 +1,100 @@
+---
+title: "Consultar processos públicos do SIPAC"
+description: "Consulte tramitação, documentos e situação de processos administrativos da UFPB pelo CLI ou MCP."
+meta:
+  contentType: "How-to"
+  category: "Começando"
+---
+
+Use a consulta pública do Sistema Integrado de Patrimônio, Administração e Contratos (SIPAC) para transformar um número de processo da Universidade Federal da Paraíba (UFPB) em dados estruturados. A consulta funciona sem login pela interface de linha de comando (CLI) e pelo Model Context Protocol (MCP).
+
+## Para que serve
+
+A integração elimina a consulta manual no portal quando você precisa acompanhar ou analisar processos administrativos. Você pode:
+
+- Confirmar o assunto, a situação e a unidade de origem
+- Identificar por quais unidades o processo passou
+- Ver quem enviou e recebeu cada movimentação
+- Listar documentos e abrir os arquivos que o portal marcou como públicos
+- Entregar os dados a um agente de inteligência artificial (IA) em um contrato JavaScript Object Notation (JSON) estável
+- Integrar a consulta a scripts sem armazenar cookies ou senhas
+
+Exemplos de uso incluem acompanhar resoluções, regimentos, solicitações administrativas, processos de compras e outras tramitações públicas da UFPB.
+
+## Consultar pelo CLI
+
+Passe o número completo no formato `00000.000000/0000-00`:
+
+```bash
+sigaa sipac process 23074.056437/2026-26
+```
+
+O comando imprime um resumo legível. Este trecho mostra a situação, o assunto e a quantidade de registros encontrados:
+
+```text
+23074.056437/2026-26  [ATIVO]
+  ANÁLISE DE PROPOSTA DE RESOLUÇÃO SOBRE DISTRIBUIÇÃO DE ENCARGOS DIDÁTICOS
+  Origin: CI - DIREÇÃO DE CENTRO (11.01.45.01)
+  Opened: 12/06/2026 17:26
+  Interested parties: 1 | Documents: 14 | Movements: 6
+```
+
+Use `--json` para receber o contrato completo:
+
+```bash
+sigaa sipac process 23074.056437/2026-26 --json
+```
+
+## Consultar pelo MCP
+
+Chame `sipac_get_public_process` com o mesmo número completo:
+
+```json
+{
+  "number": "23074.056437/2026-26"
+}
+```
+
+A tool não lê o usuário ou a senha configurados para o SIGAA. Ela consulta somente o Portal Público do SIPAC.
+
+## Entender a resposta
+
+O CLI com `--json` e a tool MCP retornam o mesmo contrato `schema_version: 1`:
+
+| Campo | Conteúdo |
+|---|---|
+| `number` | Número normalizado do processo |
+| `public_url` | Página pública de detalhes no SIPAC |
+| `origin`, `origin_unit` | Origem e unidade que abriu o processo |
+| `opened_at`, `opened_by` | Data e responsável pela autuação |
+| `subject`, `detailed_subject` | Classificação e descrição detalhada |
+| `nature`, `status` | Natureza do acesso e situação atual |
+| `interested_parties` | Interessados exibidos pelo portal |
+| `documents` | Ordem, espécie, data, origem, natureza e URL pública |
+| `movements` | Origem, destino, envio, recebimento e urgência |
+| `status_changes` | Alterações de situação registradas no processo |
+| `attached_files` | Arquivos anexos fora da lista principal de documentos |
+
+Campos e listas permanecem vazios quando o portal não apresenta aquela seção. Um documento restrito aparece nos metadados, mas não recebe `download_url`.
+
+## Conhecer os limites
+
+A integração respeita as mesmas permissões do Portal Público do SIPAC:
+
+- Não autentica no SIPAC
+- Não contorna documentos restritos ou negados
+- Não altera, movimenta ou protocola processos
+- Não armazena os resultados em banco local
+- Depende da disponibilidade e do HTML atual do portal da UFPB
+
+As respostas podem conter nomes e identificadores que o próprio portal publicou. Trate arquivos JSON, logs e documentos baixados como dados administrativos potencialmente sensíveis.
+
+## Resolver erros comuns
+
+Use a mensagem de erro para distinguir um número inválido de uma falha no portal.
+
+`invalid SIPAC process number` indica que o número não segue o formato `00000.000000/0000-00`. Confira pontos, barra, hífen e dígitos verificadores.
+
+`SIPAC process 23074.056437/2026-26 was not found` indica que o portal não retornou uma correspondência exata. Confirme o número na consulta pública da UFPB.
+
+Erros de rede ou de leitura podem indicar indisponibilidade ou mudança no portal. Tente novamente mais tarde e abra uma issue se o erro persistir para processos que o navegador encontra.

--- a/docs/sipac-processes.mdx
+++ b/docs/sipac-processes.mdx
@@ -125,7 +125,7 @@ A integração respeita as mesmas permissões do Portal Público do SIPAC:
 - Não contorna documentos restritos ou negados
 - Não altera, movimenta ou protocola processos
 - Não armazena os resultados em banco local
-- Mantém um cache curto, somente em memória, para consultas por número e nome; buscas por identificador nunca entram no cache
+- Não mantém os resultados em cache depois que a consulta termina
 - Limita cada resposta de busca aos 15 resultados da página retornada pelo portal
 - Depende da disponibilidade e do HTML atual do portal da UFPB
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "sigaa-ai-agent"
 version = "0.1.0"
-description = "User-friendly SIGAA UFPB client (CLI + MCP) for automation workflows"
+description = "User-friendly SIGAA and public SIPAC UFPB client (CLI + MCP)"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [
     { name = "Puca Vaz" },
 ]
-keywords = ["sigaa", "ufpb", "mcp", "cli", "academic"]
+keywords = ["sigaa", "sipac", "ufpb", "mcp", "cli", "academic"]
 classifiers = [
     "Environment :: Console",
     "Programming Language :: Python :: 3.11",

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -25,9 +25,11 @@ from .exporters.ics import build_calendar
 from .http import AuthError
 from .parsers.curriculum import CurriculumDataError
 from .parsers.schedule import day_name, decode_schedule
+from .parsers.sipac import SipacParseError
 from .parsers.transcript import CraUnavailableError, TranscriptParseError
 from .services import whatsnew
 from .services.sync import sync
+from .sipac import SipacClient, SipacProcessNotFound, public_process_to_dict
 from .store.db import connect
 from .store.repository import Repository
 
@@ -38,11 +40,14 @@ def main(argv: list[str] | None = None) -> int:
     if not getattr(args, "func", None):
         parser.print_help()
         return 1
-    settings = Settings()
-    if getattr(args, "user", None):
-        settings.username = args.user
-    if getattr(args, "db", None):
-        settings.db_path = args.db
+    if getattr(args, "public_without_settings", False):
+        settings = None
+    else:
+        settings = Settings()
+        if getattr(args, "user", None):
+            settings.username = args.user
+        if getattr(args, "db", None):
+            settings.db_path = args.db
     try:
         return args.func(args, settings)
     except KeyboardInterrupt:
@@ -110,6 +115,22 @@ def _build_parser() -> argparse.ArgumentParser:
     p_cra = sub.add_parser("cra", help="show the official CRA from the transcript")
     p_cra.add_argument("--json", action="store_true")
     p_cra.set_defaults(func=_cmd_cra)
+
+    p_sipac = sub.add_parser(
+        "sipac",
+        help="query SIPAC's public administrative-process portal",
+    )
+    sipac_sub = p_sipac.add_subparsers(dest="sipac_command")
+    p_sipac_process = sipac_sub.add_parser(
+        "process",
+        help="look up one public process by its full number",
+    )
+    p_sipac_process.add_argument("number", help="e.g. 23074.056437/2026-26")
+    p_sipac_process.add_argument("--json", action="store_true")
+    p_sipac_process.set_defaults(
+        func=_cmd_sipac_process,
+        public_without_settings=True,
+    )
 
     p_dl = sub.add_parser("deadlines", help="list assessment/task deadlines from the store")
     p_dl.add_argument("--class", dest="klass", help="filter by class code")
@@ -345,6 +366,23 @@ def _cmd_cra(args, settings: Settings) -> int:
     else:
         print(f"CRA: {data['value']:.2f}")
         print("Source: official academic transcript")
+    return 0
+
+
+def _cmd_sipac_process(args, settings: Settings) -> int:
+    del settings  # Public SIPAC lookup deliberately ignores stored credentials.
+    try:
+        with SipacClient() as client:
+            process = client.get_public_process(args.number)
+    except (SipacProcessNotFound, SipacParseError, ValueError, httpx.HTTPError) as exc:
+        print(f"SIPAC process lookup failed: {exc}", file=sys.stderr)
+        return 1
+
+    data = public_process_to_dict(process)
+    if args.json:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    else:
+        _print_sipac_process(data)
     return 0
 
 
@@ -681,6 +719,26 @@ def _progress_bar(percent: float, width: int = 16) -> str:
     bounded = max(0.0, min(float(percent), 100.0))
     filled = round((bounded / 100.0) * width)
     return f"[{'#' * filled}{'-' * (width - filled)}]"
+
+
+def _print_sipac_process(data: dict) -> None:
+    print(f"{data['number']}  [{data['status'] or 'status unavailable'}]")
+    print(f"  {data['detailed_subject'] or data['subject'] or 'No subject reported'}")
+    if data["origin_unit"]:
+        print(f"  Origin: {data['origin_unit']}")
+    if data["opened_at"]:
+        print(f"  Opened: {data['opened_at']}")
+    print(
+        f"  Interested parties: {len(data['interested_parties'])} | "
+        f"Documents: {len(data['documents'])} | "
+        f"Movements: {len(data['movements'])}"
+    )
+    for movement in data["movements"]:
+        print(
+            f"    {movement['sent_at']}: {movement['origin_unit']} "
+            f"-> {movement['destination_unit']}"
+        )
+    print(f"  Public URL: {data['public_url']}")
 
 
 def _fmt_schedule(raw: str) -> str:

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -29,7 +29,12 @@ from .parsers.sipac import SipacParseError
 from .parsers.transcript import CraUnavailableError, TranscriptParseError
 from .services import whatsnew
 from .services.sync import sync
-from .sipac import SipacClient, SipacProcessNotFound, public_process_to_dict
+from .sipac import (
+    SipacClient,
+    SipacProcessNotFound,
+    public_process_search_to_dict,
+    public_process_to_dict,
+)
 from .store.db import connect
 from .store.repository import Repository
 
@@ -129,6 +134,21 @@ def _build_parser() -> argparse.ArgumentParser:
     p_sipac_process.add_argument("--json", action="store_true")
     p_sipac_process.set_defaults(
         func=_cmd_sipac_process,
+        public_without_settings=True,
+    )
+    p_sipac_search = sipac_sub.add_parser(
+        "search",
+        help="search public processes by interested-party name or identifier",
+    )
+    criterion = p_sipac_search.add_mutually_exclusive_group(required=True)
+    criterion.add_argument("--name", help="interested-party name")
+    criterion.add_argument(
+        "--identifier", help="interested-party registration, CPF, or CNPJ (digits only)"
+    )
+    p_sipac_search.add_argument("--page", type=int, default=1)
+    p_sipac_search.add_argument("--json", action="store_true")
+    p_sipac_search.set_defaults(
+        func=_cmd_sipac_search,
         public_without_settings=True,
     )
 
@@ -383,6 +403,27 @@ def _cmd_sipac_process(args, settings: Settings) -> int:
         print(json.dumps(data, ensure_ascii=False, indent=2))
     else:
         _print_sipac_process(data)
+    return 0
+
+
+def _cmd_sipac_search(args, settings: Settings) -> int:
+    del settings  # Public SIPAC lookup deliberately ignores stored credentials.
+    try:
+        with SipacClient() as client:
+            page = client.search_public_processes(
+                name=args.name,
+                identifier=args.identifier,
+                page=args.page,
+            )
+    except (SipacParseError, ValueError, httpx.HTTPError) as exc:
+        print(f"SIPAC process search failed: {exc}", file=sys.stderr)
+        return 1
+
+    data = public_process_search_to_dict(page)
+    if args.json:
+        print(json.dumps(data, ensure_ascii=False, indent=2))
+    else:
+        _print_sipac_search(data)
     return 0
 
 
@@ -739,6 +780,22 @@ def _print_sipac_process(data: dict) -> None:
             f"-> {movement['destination_unit']}"
         )
     print(f"  Public URL: {data['public_url']}")
+
+
+def _print_sipac_search(data: dict) -> None:
+    pagination = data["pagination"]
+    total_pages = pagination["total_pages"] or 1
+    print(
+        f"{pagination['total_results']} public process(es) for "
+        f"{data['query']['type']} {data['query']['value']!r} "
+        f"(page {pagination['page']}/{total_pages})"
+    )
+    for result in data["results"]:
+        print(f"{result['number']}  {result['subject']}")
+        if result["interested_parties"]:
+            print(f"  Interested: {', '.join(result['interested_parties'])}")
+        print(f"  Origin: {result['origin_unit']}")
+        print(f"  Public URL: {result['public_url']}")
 
 
 def _fmt_schedule(raw: str) -> str:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -40,7 +40,12 @@ from .parsers.sipac import SipacParseError
 from .parsers.transcript import CraUnavailableError, TranscriptParseError
 from .services import whatsnew
 from .services.sync import sync as run_sync
-from .sipac import SipacClient, SipacProcessNotFound, public_process_to_dict
+from .sipac import (
+    SipacClient,
+    SipacProcessNotFound,
+    public_process_search_to_dict,
+    public_process_to_dict,
+)
 from .store.db import connect
 from .store.repository import Repository
 
@@ -279,6 +284,29 @@ def sipac_get_public_process(number: str) -> dict:
         return public_process_to_dict(process)
     except (SipacProcessNotFound, SipacParseError, ValueError, httpx.HTTPError) as exc:
         raise ToolError(f"SIPAC process lookup failed: {exc}") from None
+
+
+@mcp.tool()
+def sipac_search_public_processes(
+    name: str | None = None,
+    identifier: str | None = None,
+    page: int = 1,
+) -> dict:
+    """Search public SIPAC/UFPB processes by one interested party.
+
+    Provide exactly one criterion: ``name`` or a digits-only ``identifier``
+    (registration, CPF, or CNPJ). Results are read-only, unauthenticated, and
+    returned one portal page at a time. Use personal identifiers only for a
+    legitimate purpose and do not expose them unnecessarily.
+    """
+    try:
+        with SipacClient() as client:
+            result = client.search_public_processes(
+                name=name, identifier=identifier, page=page
+            )
+        return public_process_search_to_dict(result)
+    except (SipacParseError, ValueError, httpx.HTTPError) as exc:
+        raise ToolError(f"SIPAC process search failed: {exc}") from None
 
 
 @mcp.tool()

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -36,9 +36,11 @@ from .exporters.ics import build_calendar
 from .http import AuthError
 from .parsers.curriculum import CurriculumDataError
 from .parsers.schedule import day_name, decode_schedule
+from .parsers.sipac import SipacParseError
 from .parsers.transcript import CraUnavailableError, TranscriptParseError
 from .services import whatsnew
 from .services.sync import sync as run_sync
+from .sipac import SipacClient, SipacProcessNotFound, public_process_to_dict
 from .store.db import connect
 from .store.repository import Repository
 
@@ -260,6 +262,23 @@ def sigaa_get_curriculum(
         httpx.HTTPError,
     ) as exc:
         raise ToolError(f"curriculum lookup failed: {exc}") from None
+
+
+@mcp.tool()
+def sipac_get_public_process(number: str) -> dict:
+    """Get one administrative process from SIPAC/UFPB's public portal.
+
+    Pass the complete process number, for example 23074.056437/2026-26. This
+    read-only lookup is public and does not use or require SIGAA/SIPAC login
+    credentials. It returns general metadata, interested parties, documents,
+    movements, status changes, and attached files when the portal exposes them.
+    """
+    try:
+        with SipacClient() as client:
+            process = client.get_public_process(number)
+        return public_process_to_dict(process)
+    except (SipacProcessNotFound, SipacParseError, ValueError, httpx.HTTPError) as exc:
+        raise ToolError(f"SIPAC process lookup failed: {exc}") from None
 
 
 @mcp.tool()

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -291,3 +291,26 @@ class SipacProcess:
     movements: list[SipacMovement] = field(default_factory=list)
     status_changes: list[SipacStatusChange] = field(default_factory=list)
     attached_files: list[SipacAttachedFile] = field(default_factory=list)
+
+
+@dataclass
+class SipacProcessSearchResult:
+    """One row returned by SIPAC's public interested-party search."""
+
+    number: str
+    subject: str
+    interested_parties: list[str]
+    origin_unit: str
+    public_url: str
+
+
+@dataclass
+class SipacProcessSearchPage:
+    """One bounded page from SIPAC's public interested-party search."""
+
+    query_type: str
+    query: str
+    page: int
+    total_pages: int
+    total_results: int
+    results: list[SipacProcessSearchResult] = field(default_factory=list)

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -215,3 +215,79 @@ class Deadline:
     detail: str | None = None  # e.g. "em 10 dias"
     # JSON of the scraped event detail rows (Descrição, Período, ...), cached on demand.
     body: str | None = None
+
+
+@dataclass
+class SipacInterestedParty:
+    """One interested party listed by SIPAC's public process portal."""
+
+    kind: str
+    identifier: str
+    name: str
+
+
+@dataclass
+class SipacDocument:
+    """Public metadata for one document attached to a SIPAC process."""
+
+    order: int
+    kind: str
+    date: str
+    origin: str
+    nature: str
+    download_url: str | None = None
+
+
+@dataclass
+class SipacMovement:
+    """One routing movement in a SIPAC process."""
+
+    sent_at: str
+    origin_unit: str
+    destination_unit: str
+    sent_by: str
+    received_at: str | None
+    received_by: str | None
+    urgent: bool
+
+
+@dataclass
+class SipacStatusChange:
+    """One status change from the public process history."""
+
+    date: str
+    user: str
+    status: str
+    note: str | None = None
+
+
+@dataclass
+class SipacAttachedFile:
+    """A file exposed by SIPAC outside the main document list."""
+
+    name: str
+    description: str | None = None
+    download_url: str | None = None
+
+
+@dataclass
+class SipacProcess:
+    """Normalized public view of one administrative SIPAC process."""
+
+    number: str
+    public_url: str
+    origin: str | None = None
+    opened_at: str | None = None
+    opened_by: str | None = None
+    subject: str | None = None
+    detailed_subject: str | None = None
+    nature: str | None = None
+    origin_unit: str | None = None
+    status: str | None = None
+    registered_on: str | None = None
+    note: str | None = None
+    interested_parties: list[SipacInterestedParty] = field(default_factory=list)
+    documents: list[SipacDocument] = field(default_factory=list)
+    movements: list[SipacMovement] = field(default_factory=list)
+    status_changes: list[SipacStatusChange] = field(default_factory=list)
+    attached_files: list[SipacAttachedFile] = field(default_factory=list)

--- a/sigaa/parsers/sipac.py
+++ b/sigaa/parsers/sipac.py
@@ -23,6 +23,7 @@ PROCESS_NUMBER_RE = re.compile(
     r"^\s*(\d{5})\s*[.]\s*(\d{6})\s*[/]\s*(\d{4})\s*[-]\s*(\d{2})\s*$"
 )
 IDENTIFIER_RE = re.compile(r"^\d{1,14}$")
+NO_RESULTS_TEXT = "nenhum processo encontrado de acordo com os parâmetros de busca"
 DOCUMENT_VIEW_ONCLICK_RE = re.compile(
     r"""window[.]open[(]\s*(['"])(/public/jsp/processos/"""
     r"""documento_visualizacao[.]jsf[?]idDoc=\d+)\1\s*[,)]"""
@@ -157,7 +158,19 @@ def parse_process_search_page(
 
     text = soup.get_text(" ", strip=True)
     count_match = re.search(r"(\d+)\s+Registro\(s\)\s+Encontrado\(s\)", text, re.I)
-    total_results = int(count_match.group(1)) if count_match else len(results)
+    no_results = NO_RESULTS_TEXT in text.casefold()
+    if not results and no_results:
+        total_results = 0
+    elif not results:
+        raise SipacParseError("SIPAC search page has no official empty-result marker")
+    elif count_match is None:
+        raise SipacParseError(
+            "SIPAC search page has no result count or empty-result marker"
+        )
+    else:
+        total_results = int(count_match.group(1))
+        if total_results > 0 and not results:
+            raise SipacParseError("SIPAC reported results but no process rows were parsed")
     page_select = _pagination_select(soup)
     total_pages = len(page_select.find_all("option")) if page_select else (1 if results else 0)
     if page < 1 or (total_pages and page > total_pages):
@@ -214,7 +227,10 @@ def parse_process_detail_url(
             if link is None:
                 raise SipacParseError("SIPAC process result has no detail link")
             return _public_url(link.get("href"), base_url=base_url)
-    return None
+    text = soup.get_text(" ", strip=True).casefold()
+    if NO_RESULTS_TEXT in text:
+        return None
+    raise SipacParseError("SIPAC process result page has no matching row or empty marker")
 
 
 def parse_public_process(

--- a/sigaa/parsers/sipac.py
+++ b/sigaa/parsers/sipac.py
@@ -1,0 +1,307 @@
+"""Parsers for SIPAC/UFPB's public administrative-process portal."""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup, Tag
+
+from ..models import (
+    SipacAttachedFile,
+    SipacDocument,
+    SipacInterestedParty,
+    SipacMovement,
+    SipacProcess,
+    SipacStatusChange,
+)
+
+PUBLIC_HOST = "https://sipac.ufpb.br"
+PROCESS_NUMBER_RE = re.compile(
+    r"^\s*(\d{5})\s*[.]\s*(\d{6})\s*[/]\s*(\d{4})\s*[-]\s*(\d{2})\s*$"
+)
+
+
+class SipacParseError(ValueError):
+    """Raised when SIPAC returns a page that does not match its public contract."""
+
+
+def normalize_process_number(value: str) -> str:
+    match = PROCESS_NUMBER_RE.fullmatch(value)
+    if match is None:
+        raise ValueError(
+            "invalid SIPAC process number; expected 00000.000000/0000-00"
+        )
+    radical, sequence, year, check_digits = match.groups()
+    return f"{radical}.{sequence}/{year}-{check_digits}"
+
+
+def build_process_search_payload(html: str, process_number: str) -> dict[str, str]:
+    number = normalize_process_number(process_number)
+    radical, sequence, year, check_digits = re.split(r"[./-]", number)
+    soup = BeautifulSoup(html, "lxml")
+    form = soup.select_one("form#processoForm")
+    if form is None:
+        raise SipacParseError("SIPAC public process form was not found")
+
+    payload = {
+        field["name"]: field.get("value", "")
+        for field in form.select("input[type=hidden][name]")
+    }
+    submit = form.select_one('input[type="submit"][name]')
+    if submit is None:
+        raise SipacParseError("SIPAC public process submit control was not found")
+    payload.update(
+        {
+            "tipo_consulta": "100",
+            "RADICAL_PROTOCOLO": radical,
+            "NUM_PROTOCOLO": sequence,
+            "ANO_PROTOCOLO": year,
+            "DV_PROTOCOLO": check_digits,
+            "INTERESSADO": "",
+            "CPF_CNPJ": "",
+            submit["name"]: submit.get("value", "Consultar Processo"),
+        }
+    )
+    return payload
+
+
+def parse_process_detail_url(
+    html: str,
+    process_number: str,
+    *,
+    base_url: str = PUBLIC_HOST,
+) -> str | None:
+    number = normalize_process_number(process_number)
+    soup = BeautifulSoup(html, "lxml")
+    for table in soup.select("table.listagem"):
+        for row in _own_rows(table):
+            cells = row.find_all(["th", "td"], recursive=False)
+            if not cells or _text(cells[0]) != number:
+                continue
+            link = row.select_one('a[href*="processo_detalhado.jsf"]')
+            if link is None:
+                raise SipacParseError("SIPAC process result has no detail link")
+            return _public_url(link.get("href"), base_url=base_url)
+    return None
+
+
+def parse_public_process(
+    html: str,
+    *,
+    public_url: str,
+) -> SipacProcess:
+    soup = BeautifulSoup(html, "lxml")
+    fields = _parse_general_fields(soup)
+    number = fields.get("Processo")
+    if not number:
+        raise SipacParseError("SIPAC process detail page has no process number")
+
+    return SipacProcess(
+        number=normalize_process_number(number),
+        public_url=public_url,
+        origin=fields.get("Origem do Processo"),
+        opened_at=fields.get("Data de Autuação"),
+        opened_by=fields.get("Usuário de Autuação"),
+        subject=fields.get("Assunto do Processo"),
+        detailed_subject=fields.get("Assunto Detalhado"),
+        nature=fields.get("Natureza do Processo"),
+        origin_unit=fields.get("Unidade de Origem"),
+        status=fields.get("Status"),
+        registered_on=fields.get("Data de Cadastro"),
+        note=fields.get("Observação") or None,
+        interested_parties=_parse_interested_parties(soup),
+        documents=_parse_documents(soup),
+        movements=_parse_movements(soup),
+        status_changes=_parse_status_changes(soup),
+        attached_files=_parse_attached_files(soup),
+    )
+
+
+def _parse_general_fields(soup: BeautifulSoup) -> dict[str, str]:
+    for table in soup.find_all("table"):
+        rows = _own_rows(table)
+        if not any(_row_label(row) == "Processo" for row in rows):
+            continue
+        fields: dict[str, str] = {}
+        for row in rows:
+            cells = row.find_all(["th", "td"], recursive=False)
+            if len(cells) != 2 or cells[0].name != "th":
+                continue
+            fields[_text(cells[0]).rstrip(":")] = _text(cells[1])
+        return fields
+    raise SipacParseError("SIPAC process general-data table was not found")
+
+
+def _parse_interested_parties(soup: BeautifulSoup) -> list[SipacInterestedParty]:
+    table = _table_by_caption(soup, "Interessados Deste Processo")
+    if table is None:
+        return []
+    rows = _data_rows(table, expected_headers=["Tipo", "Identificador", "Nome"])
+    return [
+        SipacInterestedParty(kind=values[0], identifier=values[1], name=values[2])
+        for _, values in rows
+        if len(values) >= 3
+    ]
+
+
+def _parse_documents(soup: BeautifulSoup) -> list[SipacDocument]:
+    table = _table_by_caption(soup, "Documentos do Processo")
+    if table is None:
+        return []
+    rows = _data_rows(
+        table,
+        expected_headers=[
+            "Ordem",
+            "Documento (Espécie)",
+            "Data do Documento",
+            "Origem",
+            "Natureza",
+        ],
+    )
+    documents = []
+    for row, values in rows:
+        if len(values) < 5 or not values[0].isdigit():
+            continue
+        download_url = None
+        for link in row.find_all("a", href=True):
+            image = link.find("img")
+            if image and image.get("alt") == "Visualizar Documento":
+                download_url = _public_url(link.get("href"))
+                break
+        documents.append(
+            SipacDocument(
+                order=int(values[0]),
+                kind=values[1],
+                date=values[2],
+                origin=values[3],
+                nature=values[4],
+                download_url=download_url,
+            )
+        )
+    return documents
+
+
+def _parse_movements(soup: BeautifulSoup) -> list[SipacMovement]:
+    table = _table_by_caption(soup, "Movimentações do Processo")
+    if table is None:
+        return []
+    rows = _data_rows(
+        table,
+        expected_headers=[
+            "Data Origem",
+            "Unidade Origem",
+            "Unidade Destino",
+            "Enviado Por",
+            "Recebido Em",
+            "Recebido Por",
+            "Urgente",
+        ],
+    )
+    return [
+        SipacMovement(
+            sent_at=values[0],
+            origin_unit=values[1],
+            destination_unit=values[2],
+            sent_by=values[3],
+            received_at=values[4] or None,
+            received_by=values[5] or None,
+            urgent=_is_yes(values[6]),
+        )
+        for _, values in rows
+        if len(values) >= 7
+    ]
+
+
+def _parse_status_changes(soup: BeautifulSoup) -> list[SipacStatusChange]:
+    table = _table_by_caption(soup, "Alterações Ocorridas no Processo")
+    if table is None:
+        return []
+    rows = _data_rows(table, expected_headers=["Data", "Usuário", "Status", "Obs."])
+    return [
+        SipacStatusChange(
+            date=values[0],
+            user=values[1],
+            status=values[2],
+            note=values[3] or None,
+        )
+        for _, values in rows
+        if len(values) >= 4
+    ]
+
+
+def _parse_attached_files(soup: BeautifulSoup) -> list[SipacAttachedFile]:
+    table = _table_by_caption(soup, "Arquivos anexados ao Processo")
+    if table is None:
+        return []
+    rows = _data_rows(table, expected_headers=["Nome", "Descrição"])
+    attached = []
+    for row, values in rows:
+        if not values:
+            continue
+        link = row.find("a", href=True)
+        description = values[1] if len(values) > 1 and values[1] else None
+        attached.append(
+            SipacAttachedFile(
+                name=values[0],
+                description=description,
+                download_url=_public_url(link.get("href")) if link else None,
+            )
+        )
+    return attached
+
+
+def _table_by_caption(soup: BeautifulSoup, caption_text: str) -> Tag | None:
+    for table in soup.find_all("table"):
+        caption = table.find("caption", recursive=False)
+        if caption is not None and _text(caption) == caption_text:
+            return table
+    return None
+
+
+def _own_rows(table: Tag) -> list[Tag]:
+    return [row for row in table.find_all("tr") if row.find_parent("table") is table]
+
+
+def _data_rows(
+    table: Tag,
+    *,
+    expected_headers: list[str],
+) -> list[tuple[Tag, list[str]]]:
+    rows = _own_rows(table)
+    if not rows:
+        return []
+    header = [_text(cell) for cell in rows[0].find_all(["th", "td"], recursive=False)]
+    if header[: len(expected_headers)] != expected_headers:
+        raise SipacParseError(
+            f"unexpected columns in SIPAC table {_text(table.find('caption'))!r}"
+        )
+    return [
+        (row, [_text(cell) for cell in row.find_all(["th", "td"], recursive=False)])
+        for row in rows[1:]
+    ]
+
+
+def _row_label(row: Tag) -> str | None:
+    first = row.find(["th", "td"], recursive=False)
+    if first is None or first.name != "th":
+        return None
+    return _text(first).rstrip(":")
+
+
+def _public_url(href: str | None, *, base_url: str = PUBLIC_HOST) -> str | None:
+    if not href or href.startswith("#") or href.lower().startswith("javascript:"):
+        return None
+    url = urljoin(base_url, href)
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or parsed.netloc != "sipac.ufpb.br":
+        return None
+    return url
+
+
+def _is_yes(value: str) -> bool:
+    return value.casefold() in {"sim", "yes", "true"}
+
+
+def _text(element: Tag | None) -> str:
+    return element.get_text(" ", strip=True) if element is not None else ""

--- a/sigaa/parsers/sipac.py
+++ b/sigaa/parsers/sipac.py
@@ -13,12 +13,19 @@ from ..models import (
     SipacInterestedParty,
     SipacMovement,
     SipacProcess,
+    SipacProcessSearchPage,
+    SipacProcessSearchResult,
     SipacStatusChange,
 )
 
 PUBLIC_HOST = "https://sipac.ufpb.br"
 PROCESS_NUMBER_RE = re.compile(
     r"^\s*(\d{5})\s*[.]\s*(\d{6})\s*[/]\s*(\d{4})\s*[-]\s*(\d{2})\s*$"
+)
+IDENTIFIER_RE = re.compile(r"^\d{1,14}$")
+DOCUMENT_VIEW_ONCLICK_RE = re.compile(
+    r"""window[.]open[(]\s*(['"])(/public/jsp/processos/"""
+    r"""documento_visualizacao[.]jsf[?]idDoc=\d+)\1\s*[,)]"""
 )
 
 
@@ -64,6 +71,130 @@ def build_process_search_payload(html: str, process_number: str) -> dict[str, st
         }
     )
     return payload
+
+
+def build_interested_search_payload(
+    html: str,
+    *,
+    name: str | None = None,
+    identifier: str | None = None,
+) -> tuple[str, str, dict[str, str]]:
+    """Build the observed JSF payload for one public interested-party query."""
+    query_type, query = normalize_interested_search(name=name, identifier=identifier)
+    soup = BeautifulSoup(html, "lxml")
+    form = soup.select_one("form#processoForm")
+    if form is None:
+        raise SipacParseError("SIPAC public process form was not found")
+    payload = {
+        field["name"]: field.get("value", "")
+        for field in form.select("input[type=hidden][name]")
+    }
+    submit = form.select_one('input[type="submit"][name]')
+    if submit is None:
+        raise SipacParseError("SIPAC public process submit control was not found")
+    payload.update(
+        {
+            "tipo_consulta": "200" if query_type == "name" else "300",
+            "RADICAL_PROTOCOLO": "23074",
+            "NUM_PROTOCOLO": "",
+            "ANO_PROTOCOLO": "",
+            "DV_PROTOCOLO": "",
+            "INTERESSADO": query if query_type == "name" else "",
+            "CPF_CNPJ": query if query_type == "identifier" else "",
+            submit["name"]: submit.get("value", "Consultar Processo"),
+        }
+    )
+    return query_type, query, payload
+
+
+def normalize_interested_search(
+    *, name: str | None = None, identifier: str | None = None
+) -> tuple[str, str]:
+    if (name is None) == (identifier is None):
+        raise ValueError("provide exactly one SIPAC search field: name or identifier")
+    if name is not None:
+        query = " ".join(name.split())
+        if not 3 <= len(query) <= 200:
+            raise ValueError("SIPAC interested-party name must have 3 to 200 characters")
+        return "name", query
+    query = "".join(identifier.split()) if identifier is not None else ""
+    if IDENTIFIER_RE.fullmatch(query) is None:
+        raise ValueError("SIPAC identifier must contain 1 to 14 digits only")
+    return "identifier", query
+
+
+def parse_process_search_page(
+    html: str,
+    *,
+    query_type: str,
+    query: str,
+    page: int,
+) -> SipacProcessSearchPage:
+    soup = BeautifulSoup(html, "lxml")
+    results: list[SipacProcessSearchResult] = []
+    for table in soup.select("table.listagem"):
+        for row in _own_rows(table):
+            cells = row.find_all(["th", "td"], recursive=False)
+            if len(cells) < 4:
+                continue
+            try:
+                number = normalize_process_number(_text(cells[0]))
+            except ValueError:
+                continue
+            link = row.select_one('a[href*="processo_detalhado.jsf"]')
+            public_url = _public_url(link.get("href") if link else None)
+            if public_url is None:
+                raise SipacParseError("SIPAC process result has no safe detail link")
+            results.append(
+                SipacProcessSearchResult(
+                    number=number,
+                    subject=_text(cells[1]),
+                    interested_parties=list(cells[2].stripped_strings),
+                    origin_unit=_text(cells[3]),
+                    public_url=public_url,
+                )
+            )
+
+    text = soup.get_text(" ", strip=True)
+    count_match = re.search(r"(\d+)\s+Registro\(s\)\s+Encontrado\(s\)", text, re.I)
+    total_results = int(count_match.group(1)) if count_match else len(results)
+    page_select = _pagination_select(soup)
+    total_pages = len(page_select.find_all("option")) if page_select else (1 if results else 0)
+    if page < 1 or (total_pages and page > total_pages):
+        raise ValueError(f"SIPAC search page must be between 1 and {total_pages}")
+    return SipacProcessSearchPage(
+        query_type=query_type,
+        query=query,
+        page=page,
+        total_pages=total_pages,
+        total_results=total_results,
+        results=results,
+    )
+
+
+def build_results_page_request(
+    html: str, page: int, *, base_url: str = PUBLIC_HOST
+) -> tuple[str, dict[str, str]]:
+    """Replay SIPAC's dynamic JSF result form for a one-based page number."""
+    if page < 2:
+        raise ValueError("pagination request requires page 2 or greater")
+    soup = BeautifulSoup(html, "lxml")
+    form = soup.select_one("form#documentoForm")
+    page_select = _pagination_select(soup)
+    if form is None or page_select is None or not page_select.get("name"):
+        raise SipacParseError("SIPAC result pagination form was not found")
+    options = page_select.find_all("option")
+    if page > len(options):
+        raise ValueError(f"SIPAC search page must be between 1 and {len(options)}")
+    payload = {
+        field["name"]: field.get("value", "")
+        for field in form.select("input[type=hidden][name]")
+    }
+    payload[page_select["name"]] = options[page - 1].get("value", str(page - 1))
+    action = _public_url(form.get("action"), base_url=base_url)
+    if action is None:
+        raise SipacParseError("SIPAC result pagination action is not safe")
+    return action, payload
 
 
 def parse_process_detail_url(
@@ -168,6 +299,8 @@ def _parse_documents(soup: BeautifulSoup) -> list[SipacDocument]:
             image = link.find("img")
             if image and image.get("alt") == "Visualizar Documento":
                 download_url = _public_url(link.get("href"))
+                if download_url is None:
+                    download_url = _document_view_url(link.get("onclick"))
                 break
         documents.append(
             SipacDocument(
@@ -259,6 +392,17 @@ def _table_by_caption(soup: BeautifulSoup, caption_text: str) -> Tag | None:
     return None
 
 
+def _pagination_select(soup: BeautifulSoup) -> Tag | None:
+    form = soup.select_one("form#documentoForm")
+    if form is None:
+        return None
+    for select in form.find_all("select", attrs={"name": True}):
+        options = select.find_all("option")
+        if options and all(_text(option).casefold().startswith("pag.") for option in options):
+            return select
+    return None
+
+
 def _own_rows(table: Tag) -> list[Tag]:
     return [row for row in table.find_all("tr") if row.find_parent("table") is table]
 
@@ -297,6 +441,15 @@ def _public_url(href: str | None, *, base_url: str = PUBLIC_HOST) -> str | None:
     if parsed.scheme != "https" or parsed.netloc != "sipac.ufpb.br":
         return None
     return url
+
+
+def _document_view_url(onclick: str | None) -> str | None:
+    if not onclick:
+        return None
+    match = DOCUMENT_VIEW_ONCLICK_RE.search(onclick)
+    if match is None:
+        return None
+    return _public_url(match.group(2))
 
 
 def _is_yes(value: str) -> bool:

--- a/sigaa/sipac.py
+++ b/sigaa/sipac.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from collections import OrderedDict
-from copy import deepcopy
 from dataclasses import asdict
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 import threading
 import time
-from typing import Any, Callable, MutableMapping
+from typing import Callable
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -33,8 +31,8 @@ PROCESS_SEARCH_URL = f"{PUBLIC_HOST}/public/jsp/processos/consulta_processo.jsf"
 _REDIRECT_STATUSES = {301, 302, 303, 307, 308}
 _TRANSIENT_STATUSES = {429, 500, 502, 503, 504}
 _MAX_REDIRECTS = 5
-_DEFAULT_CACHE_TTL = 60.0
-_DEFAULT_CACHE_MAX_ENTRIES = 128
+_MAX_AUTOMATIC_RETRY_AFTER = 30.0
+_MAX_SHARED_COOLDOWN = 3600.0
 
 
 class _RateLimiter:
@@ -49,21 +47,32 @@ class _RateLimiter:
         self.clock = clock
         self.sleep = sleep
         self.last_request_at: float | None = None
+        self.blocked_until = 0.0
         self.lock = threading.Lock()
 
     def wait(self) -> None:
+        while True:
+            with self.lock:
+                now = self.clock()
+                embargo_delay = self.blocked_until - now
+                if self.last_request_at is not None:
+                    interval_delay = self.interval - (now - self.last_request_at)
+                else:
+                    interval_delay = 0.0
+                delay = max(embargo_delay, interval_delay)
+                if delay <= 0:
+                    self.last_request_at = now
+                    return
+            # Do not hold the lock while sleeping: a concurrent 429 must be able
+            # to extend the embargo before this request is allowed through.
+            self.sleep(delay)
+
+    def defer(self, delay: float) -> None:
+        """Apply one server-requested cooldown to every client sharing this limiter."""
         with self.lock:
-            now = self.clock()
-            if self.last_request_at is not None:
-                delay = self.interval - (now - self.last_request_at)
-                if delay > 0:
-                    self.sleep(delay)
-                    now = self.clock()
-            self.last_request_at = now
+            self.blocked_until = max(self.blocked_until, self.clock() + delay)
 
 
-_SHARED_CACHE: OrderedDict[str, tuple[float, Any]] = OrderedDict()
-_SHARED_CACHE_LOCK = threading.Lock()
 _SHARED_RATE_LIMITER = _RateLimiter(
     0.25,
     clock=time.monotonic,
@@ -85,11 +94,8 @@ class SipacClient:
         clock: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
         min_request_interval: float = 0.25,
-        cache_ttl: float = _DEFAULT_CACHE_TTL,
-        cache_max_entries: int = _DEFAULT_CACHE_MAX_ENTRIES,
         max_retries: int = 2,
         retry_backoff: float = 0.25,
-        cache: MutableMapping[str, tuple[float, Any]] | None = None,
     ):
         owns_client = client is None
         self._client = client or httpx.Client(
@@ -99,19 +105,8 @@ class SipacClient:
         )
         self._clock = clock
         self._sleep = sleep
-        self._cache_ttl = max(0.0, cache_ttl)
-        self._cache_max_entries = max(0, cache_max_entries)
         self._max_retries = max(0, max_retries)
         self._retry_backoff = max(0.0, retry_backoff)
-        if cache is not None:
-            self._cache = cache
-            self._cache_lock = threading.Lock()
-        elif owns_client:
-            self._cache = _SHARED_CACHE
-            self._cache_lock = _SHARED_CACHE_LOCK
-        else:
-            self._cache = OrderedDict()
-            self._cache_lock = threading.Lock()
         self._rate_limiter = (
             _SHARED_RATE_LIMITER
             if owns_client
@@ -127,11 +122,6 @@ class SipacClient:
 
     def get_public_process(self, process_number: str) -> SipacProcess:
         number = normalize_process_number(process_number)
-        cache_key = f"process:{number}"
-        cached = self._get_cached(cache_key)
-        if cached is not None:
-            return cached
-
         form = self._request("GET", PROCESS_SEARCH_URL)
         form.raise_for_status()
         payload = build_process_search_payload(form.text, number)
@@ -147,7 +137,6 @@ class SipacClient:
         process = parse_public_process(detail.text, public_url=detail_url)
         if process.number != number:
             raise SipacParseError("SIPAC returned a different process than requested")
-        self._put_cached(cache_key, process)
         return process
 
     def search_public_processes(
@@ -162,15 +151,6 @@ class SipacClient:
         query_type, query = normalize_interested_search(
             name=name, identifier=identifier
         )
-        cache_key = (
-            f"search:{query_type}:{query.casefold()}:{page}"
-            if query_type == "name"
-            else None
-        )
-        cached = self._get_cached(cache_key) if cache_key is not None else None
-        if cached is not None:
-            return cached
-
         form = self._request("GET", PROCESS_SEARCH_URL)
         form.raise_for_status()
         payload_type, payload_query, payload = build_interested_search_payload(
@@ -190,8 +170,6 @@ class SipacClient:
         parsed = parse_process_search_page(
             results_html, query_type=query_type, query=query, page=page
         )
-        if cache_key is not None:
-            self._put_cached(cache_key, parsed)
         return parsed
 
     def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
@@ -245,28 +223,36 @@ class SipacClient:
                 if attempt == self._max_retries:
                     raise
             else:
-                if (
-                    response.status_code not in _TRANSIENT_STATUSES
-                    or attempt == self._max_retries
-                ):
+                if response.status_code not in _TRANSIENT_STATUSES:
                     return response
-                retry_delay = self._retry_delay(response, attempt)
-                if retry_delay is None:
+                if response.status_code == 429:
+                    retry_after = self._retry_after_seconds(response)
+                    if retry_after is None:
+                        return response
+                    self._rate_limiter.defer(retry_after)
+                    if (
+                        attempt == self._max_retries
+                        or retry_after > _MAX_AUTOMATIC_RETRY_AFTER
+                    ):
+                        return response
+                    response.close()
+                    continue
+                if attempt == self._max_retries:
                     return response
                 response.close()
             self._sleep(retry_delay)
         raise AssertionError("unreachable")  # pragma: no cover
 
-    def _retry_delay(self, response: httpx.Response, attempt: int) -> float | None:
-        backoff = self._retry_backoff * (2**attempt)
-        if response.status_code != 429:
-            return backoff
+    @staticmethod
+    def _retry_after_seconds(response: httpx.Response) -> float | None:
         header = response.headers.get("retry-after")
         if header is None:
             return None
-        try:
-            requested = float(header)
-        except ValueError:
+        if header.isascii() and header.isdecimal():
+            if len(header) > 10:
+                return None
+            requested = float(int(header))
+        else:
             try:
                 retry_at = parsedate_to_datetime(header)
                 if retry_at.tzinfo is None:
@@ -274,7 +260,8 @@ class SipacClient:
                 requested = (retry_at - datetime.now(timezone.utc)).total_seconds()
             except (TypeError, ValueError, OverflowError):
                 return None
-        return max(backoff, min(max(0.0, requested), 30.0))
+        requested = max(0.0, requested)
+        return requested if requested <= _MAX_SHARED_COOLDOWN else None
 
     @staticmethod
     def _validated_url(url: str) -> str:
@@ -288,40 +275,6 @@ class SipacClient:
         ):
             raise ValueError("SIPAC refused a redirect outside its public HTTPS host")
         return url
-
-    def _get_cached(self, key: str) -> Any | None:
-        if self._cache_ttl <= 0 or self._cache_max_entries <= 0:
-            return None
-        now = self._clock()
-        with self._cache_lock:
-            self._prune_expired_locked(now)
-            cached = self._cache.get(key)
-            if cached is None:
-                return None
-            expires_at, process = cached
-            if expires_at <= now:
-                del self._cache[key]
-                return None
-            if isinstance(self._cache, OrderedDict):
-                self._cache.move_to_end(key)
-            return deepcopy(process)
-
-    def _put_cached(self, key: str, value: Any) -> None:
-        if self._cache_ttl <= 0 or self._cache_max_entries <= 0:
-            return
-        with self._cache_lock:
-            now = self._clock()
-            self._prune_expired_locked(now)
-            self._cache[key] = (now + self._cache_ttl, deepcopy(value))
-            if isinstance(self._cache, OrderedDict):
-                self._cache.move_to_end(key)
-                while len(self._cache) > self._cache_max_entries:
-                    self._cache.popitem(last=False)
-
-    def _prune_expired_locked(self, now: float) -> None:
-        expired = [key for key, (expires_at, _) in self._cache.items() if expires_at <= now]
-        for key in expired:
-            del self._cache[key]
 
     def close(self) -> None:
         self._client.close()

--- a/sigaa/sipac.py
+++ b/sigaa/sipac.py
@@ -1,0 +1,73 @@
+"""Public SIPAC/UFPB client and shared process presentation contract."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+import httpx
+
+from .config import USER_AGENT
+from .models import SipacProcess
+from .parsers.sipac import (
+    PUBLIC_HOST,
+    SipacParseError,
+    build_process_search_payload,
+    normalize_process_number,
+    parse_process_detail_url,
+    parse_public_process,
+)
+
+PROCESS_SEARCH_URL = f"{PUBLIC_HOST}/public/jsp/processos/consulta_processo.jsf"
+
+
+class SipacProcessNotFound(LookupError):
+    pass
+
+
+class SipacClient:
+    """Read-only client for SIPAC's unauthenticated public portal."""
+
+    def __init__(self, client: httpx.Client | None = None):
+        self._client = client or httpx.Client(
+            headers={"User-Agent": USER_AGENT},
+            follow_redirects=True,
+            timeout=30.0,
+        )
+
+    def get_public_process(self, process_number: str) -> SipacProcess:
+        number = normalize_process_number(process_number)
+        form = self._client.get(PROCESS_SEARCH_URL)
+        form.raise_for_status()
+        payload = build_process_search_payload(form.text, number)
+
+        results = self._client.post(PROCESS_SEARCH_URL, data=payload)
+        results.raise_for_status()
+        detail_url = parse_process_detail_url(results.text, number)
+        if detail_url is None:
+            raise SipacProcessNotFound(f"SIPAC process {number} was not found")
+
+        detail = self._client.get(detail_url)
+        detail.raise_for_status()
+        process = parse_public_process(detail.text, public_url=detail_url)
+        if process.number != number:
+            raise SipacParseError("SIPAC returned a different process than requested")
+        return process
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "SipacClient":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+
+def public_process_to_dict(process: SipacProcess) -> dict:
+    """Stable JSON contract shared by the SIPAC CLI and MCP tool."""
+    data = asdict(process)
+    return {
+        "schema_version": 1,
+        "source": "sipac_ufpb_public_portal",
+        **data,
+    }

--- a/sigaa/sipac.py
+++ b/sigaa/sipac.py
@@ -2,22 +2,73 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from copy import deepcopy
 from dataclasses import asdict
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+import threading
+import time
+from typing import Any, Callable, MutableMapping
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
 from .config import USER_AGENT
-from .models import SipacProcess
+from .models import SipacProcess, SipacProcessSearchPage
 from .parsers.sipac import (
     PUBLIC_HOST,
     SipacParseError,
+    build_interested_search_payload,
     build_process_search_payload,
+    build_results_page_request,
+    normalize_interested_search,
     normalize_process_number,
     parse_process_detail_url,
+    parse_process_search_page,
     parse_public_process,
 )
 
 PROCESS_SEARCH_URL = f"{PUBLIC_HOST}/public/jsp/processos/consulta_processo.jsf"
+_REDIRECT_STATUSES = {301, 302, 303, 307, 308}
+_TRANSIENT_STATUSES = {429, 500, 502, 503, 504}
+_MAX_REDIRECTS = 5
+_DEFAULT_CACHE_TTL = 60.0
+_DEFAULT_CACHE_MAX_ENTRIES = 128
+
+
+class _RateLimiter:
+    def __init__(
+        self,
+        interval: float,
+        *,
+        clock: Callable[[], float],
+        sleep: Callable[[float], None],
+    ):
+        self.interval = max(0.0, interval)
+        self.clock = clock
+        self.sleep = sleep
+        self.last_request_at: float | None = None
+        self.lock = threading.Lock()
+
+    def wait(self) -> None:
+        with self.lock:
+            now = self.clock()
+            if self.last_request_at is not None:
+                delay = self.interval - (now - self.last_request_at)
+                if delay > 0:
+                    self.sleep(delay)
+                    now = self.clock()
+            self.last_request_at = now
+
+
+_SHARED_CACHE: OrderedDict[str, tuple[float, Any]] = OrderedDict()
+_SHARED_CACHE_LOCK = threading.Lock()
+_SHARED_RATE_LIMITER = _RateLimiter(
+    0.25,
+    clock=time.monotonic,
+    sleep=time.sleep,
+)
 
 
 class SipacProcessNotFound(LookupError):
@@ -27,31 +78,250 @@ class SipacProcessNotFound(LookupError):
 class SipacClient:
     """Read-only client for SIPAC's unauthenticated public portal."""
 
-    def __init__(self, client: httpx.Client | None = None):
+    def __init__(
+        self,
+        client: httpx.Client | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], None] = time.sleep,
+        min_request_interval: float = 0.25,
+        cache_ttl: float = _DEFAULT_CACHE_TTL,
+        cache_max_entries: int = _DEFAULT_CACHE_MAX_ENTRIES,
+        max_retries: int = 2,
+        retry_backoff: float = 0.25,
+        cache: MutableMapping[str, tuple[float, Any]] | None = None,
+    ):
+        owns_client = client is None
         self._client = client or httpx.Client(
             headers={"User-Agent": USER_AGENT},
-            follow_redirects=True,
+            follow_redirects=False,
             timeout=30.0,
+        )
+        self._clock = clock
+        self._sleep = sleep
+        self._cache_ttl = max(0.0, cache_ttl)
+        self._cache_max_entries = max(0, cache_max_entries)
+        self._max_retries = max(0, max_retries)
+        self._retry_backoff = max(0.0, retry_backoff)
+        if cache is not None:
+            self._cache = cache
+            self._cache_lock = threading.Lock()
+        elif owns_client:
+            self._cache = _SHARED_CACHE
+            self._cache_lock = _SHARED_CACHE_LOCK
+        else:
+            self._cache = OrderedDict()
+            self._cache_lock = threading.Lock()
+        self._rate_limiter = (
+            _SHARED_RATE_LIMITER
+            if owns_client
+            and clock is time.monotonic
+            and sleep is time.sleep
+            and min_request_interval == 0.25
+            else _RateLimiter(
+                min_request_interval,
+                clock=clock,
+                sleep=sleep,
+            )
         )
 
     def get_public_process(self, process_number: str) -> SipacProcess:
         number = normalize_process_number(process_number)
-        form = self._client.get(PROCESS_SEARCH_URL)
+        cache_key = f"process:{number}"
+        cached = self._get_cached(cache_key)
+        if cached is not None:
+            return cached
+
+        form = self._request("GET", PROCESS_SEARCH_URL)
         form.raise_for_status()
         payload = build_process_search_payload(form.text, number)
 
-        results = self._client.post(PROCESS_SEARCH_URL, data=payload)
+        results = self._request("POST", PROCESS_SEARCH_URL, data=payload)
         results.raise_for_status()
         detail_url = parse_process_detail_url(results.text, number)
         if detail_url is None:
             raise SipacProcessNotFound(f"SIPAC process {number} was not found")
 
-        detail = self._client.get(detail_url)
+        detail = self._request("GET", detail_url)
         detail.raise_for_status()
         process = parse_public_process(detail.text, public_url=detail_url)
         if process.number != number:
             raise SipacParseError("SIPAC returned a different process than requested")
+        self._put_cached(cache_key, process)
         return process
+
+    def search_public_processes(
+        self,
+        *,
+        name: str | None = None,
+        identifier: str | None = None,
+        page: int = 1,
+    ) -> SipacProcessSearchPage:
+        if page < 1:
+            raise ValueError("SIPAC search page must be 1 or greater")
+        query_type, query = normalize_interested_search(
+            name=name, identifier=identifier
+        )
+        cache_key = (
+            f"search:{query_type}:{query.casefold()}:{page}"
+            if query_type == "name"
+            else None
+        )
+        cached = self._get_cached(cache_key) if cache_key is not None else None
+        if cached is not None:
+            return cached
+
+        form = self._request("GET", PROCESS_SEARCH_URL)
+        form.raise_for_status()
+        payload_type, payload_query, payload = build_interested_search_payload(
+            form.text, name=name, identifier=identifier
+        )
+        if (payload_type, payload_query) != (query_type, query):
+            raise SipacParseError("SIPAC search criteria changed while building payload")
+
+        results = self._request("POST", PROCESS_SEARCH_URL, data=payload)
+        results.raise_for_status()
+        results_html = results.text
+        if page > 1:
+            page_url, page_payload = build_results_page_request(results_html, page)
+            results = self._request("POST", page_url, data=page_payload)
+            results.raise_for_status()
+            results_html = results.text
+        parsed = parse_process_search_page(
+            results_html, query_type=query_type, query=query, page=page
+        )
+        if cache_key is not None:
+            self._put_cached(cache_key, parsed)
+        return parsed
+
+    def _request(self, method: str, url: str, **kwargs) -> httpx.Response:
+        current_method = method
+        current_url = self._validated_url(url)
+        current_kwargs = kwargs
+        for redirect_count in range(_MAX_REDIRECTS + 1):
+            response = self._request_with_retries(
+                current_method,
+                current_url,
+                **current_kwargs,
+            )
+            if response.status_code not in _REDIRECT_STATUSES:
+                return response
+            if redirect_count == _MAX_REDIRECTS:
+                response.close()
+                raise httpx.TooManyRedirects(
+                    "SIPAC exceeded the redirect limit",
+                    request=response.request,
+                )
+            location = response.headers.get("location")
+            if not location:
+                return response
+            next_url = self._validated_url(urljoin(str(response.url), location))
+            if response.status_code == 303 or (
+                response.status_code in {301, 302} and current_method != "GET"
+            ):
+                current_method = "GET"
+                current_kwargs = {}
+            response.close()
+            current_url = next_url
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    def _request_with_retries(
+        self,
+        method: str,
+        url: str,
+        **kwargs,
+    ) -> httpx.Response:
+        for attempt in range(self._max_retries + 1):
+            self._rate_limiter.wait()
+            retry_delay = self._retry_backoff * (2**attempt)
+            try:
+                response = self._client.request(
+                    method,
+                    url,
+                    follow_redirects=False,
+                    **kwargs,
+                )
+            except httpx.TransportError:
+                if attempt == self._max_retries:
+                    raise
+            else:
+                if (
+                    response.status_code not in _TRANSIENT_STATUSES
+                    or attempt == self._max_retries
+                ):
+                    return response
+                retry_delay = self._retry_delay(response, attempt)
+                if retry_delay is None:
+                    return response
+                response.close()
+            self._sleep(retry_delay)
+        raise AssertionError("unreachable")  # pragma: no cover
+
+    def _retry_delay(self, response: httpx.Response, attempt: int) -> float | None:
+        backoff = self._retry_backoff * (2**attempt)
+        if response.status_code != 429:
+            return backoff
+        header = response.headers.get("retry-after")
+        if header is None:
+            return None
+        try:
+            requested = float(header)
+        except ValueError:
+            try:
+                retry_at = parsedate_to_datetime(header)
+                if retry_at.tzinfo is None:
+                    retry_at = retry_at.replace(tzinfo=timezone.utc)
+                requested = (retry_at - datetime.now(timezone.utc)).total_seconds()
+            except (TypeError, ValueError, OverflowError):
+                return None
+        return max(backoff, min(max(0.0, requested), 30.0))
+
+    @staticmethod
+    def _validated_url(url: str) -> str:
+        parsed = urlparse(url)
+        if (
+            parsed.scheme != "https"
+            or parsed.hostname != "sipac.ufpb.br"
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.port not in {None, 443}
+        ):
+            raise ValueError("SIPAC refused a redirect outside its public HTTPS host")
+        return url
+
+    def _get_cached(self, key: str) -> Any | None:
+        if self._cache_ttl <= 0 or self._cache_max_entries <= 0:
+            return None
+        now = self._clock()
+        with self._cache_lock:
+            self._prune_expired_locked(now)
+            cached = self._cache.get(key)
+            if cached is None:
+                return None
+            expires_at, process = cached
+            if expires_at <= now:
+                del self._cache[key]
+                return None
+            if isinstance(self._cache, OrderedDict):
+                self._cache.move_to_end(key)
+            return deepcopy(process)
+
+    def _put_cached(self, key: str, value: Any) -> None:
+        if self._cache_ttl <= 0 or self._cache_max_entries <= 0:
+            return
+        with self._cache_lock:
+            now = self._clock()
+            self._prune_expired_locked(now)
+            self._cache[key] = (now + self._cache_ttl, deepcopy(value))
+            if isinstance(self._cache, OrderedDict):
+                self._cache.move_to_end(key)
+                while len(self._cache) > self._cache_max_entries:
+                    self._cache.popitem(last=False)
+
+    def _prune_expired_locked(self, now: float) -> None:
+        expired = [key for key, (expires_at, _) in self._cache.items() if expires_at <= now]
+        for key in expired:
+            del self._cache[key]
 
     def close(self) -> None:
         self._client.close()
@@ -70,4 +340,21 @@ def public_process_to_dict(process: SipacProcess) -> dict:
         "schema_version": 1,
         "source": "sipac_ufpb_public_portal",
         **data,
+    }
+
+
+def public_process_search_to_dict(page: SipacProcessSearchPage) -> dict:
+    """Stable JSON contract shared by SIPAC search CLI and MCP tool."""
+    return {
+        "schema_version": 1,
+        "source": "sipac_ufpb_public_portal",
+        "query": {"type": page.query_type, "value": page.query},
+        "pagination": {
+            "page": page.page,
+            "total_pages": page.total_pages,
+            "total_results": page.total_results,
+            "returned_results": len(page.results),
+            "page_size": 15,
+        },
+        "results": [asdict(result) for result in page.results],
     }

--- a/tests/fixtures/sipac_interested_results.html
+++ b/tests/fixtures/sipac_interested_results.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html><body>
+<div>31 Registro(s) Encontrado(s)</div>
+<form id="documentoForm" name="documentoForm" method="post"
+      action="/public/jsp/processos/processos.jsf">
+  <input type="hidden" name="documentoForm" value="documentoForm">
+  <input type="hidden" name="tipo_consulta" value="200">
+  <input type="hidden" name="INTERESSADO" value="JANE EXAMPLE">
+  <input type="hidden" name="CPF_CNPJ" value="">
+  <input type="hidden" name="javax.faces.ViewState" value="j_id4">
+  <table class="listagem">
+    <tr><th>Número</th><th>Assunto</th><th>Interessado</th><th>Origem</th><th></th></tr>
+    <tr>
+      <td>23074.000001/2099-10</td>
+      <td>PROCESSO SINTÉTICO PARA TESTES</td>
+      <td>JANE EXAMPLE<br>OTHER UNIT</td>
+      <td>UNIDADE DE TESTE (00.00.00)</td>
+      <td><a href="/public/jsp/processos/processo_detalhado.jsf?id=123">Visualizar Processo</a></td>
+    </tr>
+  </table>
+  <select name="documentoForm:dynamic_page">
+    <option value="0" selected>Pag. 1</option>
+    <option value="1">Pag. 2</option>
+    <option value="2">Pag. 3</option>
+  </select>
+</form>
+</body></html>

--- a/tests/fixtures/sipac_process.html
+++ b/tests/fixtures/sipac_process.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html><body>
+<h2>Consulta do Processo 23074.000001/2099-10</h2>
+<table class="formulario"><tbody><tr><td>
+  <table class="formulario"><tbody>
+    <tr><th>Processo:</th><td>23074.000001/2099-10</td></tr>
+    <tr><th>Origem do Processo:</th><td>Interno</td></tr>
+    <tr><th>Data de Autuação:</th><td>01/01/2099 10:00</td></tr>
+    <tr><th>Usuário de Autuação:</th><td>USUÁRIO DE TESTE</td></tr>
+    <tr><th>Assunto do Processo:</th><td>000 - ASSUNTO SINTÉTICO</td></tr>
+    <tr><th>Assunto Detalhado:</th><td>PROCESSO SINTÉTICO PARA TESTES</td></tr>
+    <tr><th>Natureza do Processo:</th><td>OSTENSIVO</td></tr>
+    <tr><th>Unidade de Origem:</th><td>UNIDADE DE TESTE (00.00.00)</td></tr>
+    <tr><th>Status:</th><td>ATIVO</td></tr>
+    <tr><th>Data de Cadastro:</th><td>01/01/2099</td></tr>
+    <tr><th>Observação:</th><td>Sem dados reais.</td></tr>
+  </tbody></table>
+  <table class="subListagem">
+    <caption>Interessados Deste Processo</caption>
+    <thead><tr><th>Tipo</th><th>Identificador</th><th>Nome</th></tr></thead>
+    <tbody><tr><td>Unidade</td><td>000000</td><td>UNIDADE DE TESTE</td></tr></tbody>
+  </table>
+  <table class="subListagem">
+    <caption>Documentos do Processo</caption>
+    <thead><tr><th>Ordem</th><th>Documento (Espécie)</th><th>Data do Documento</th><th>Origem</th><th>Natureza</th><th></th><th></th></tr></thead>
+    <tbody>
+      <tr><td>1</td><td>OFÍCIO</td><td>01/01/2099</td><td>TESTE (00.00.00)</td><td>OSTENSIVO</td><td><a href="/public/verArquivoDocumento?idArquivo=1"><img alt="Visualizar Documento"></a></td><td></td></tr>
+      <tr><td>2</td><td>ANEXO</td><td>02/01/2099</td><td>TESTE (00.00.00)</td><td>RESTRITO</td><td><a href="#"><img alt="Visualizar Documento"></a></td><td></td></tr>
+    </tbody>
+  </table>
+  <table class="subListagem">
+    <caption>Movimentações do Processo</caption>
+    <thead><tr><th>Data Origem</th><th>Unidade Origem</th><th>Unidade Destino</th><th>Enviado Por</th><th>Recebido Em</th><th>Recebido Por</th><th>Urgente</th></tr></thead>
+    <tbody><tr><td>01/01/2099 10:00</td><td>ORIGEM</td><td>DESTINO</td><td>remetente</td><td>02/01/2099 11:00</td><td>destinatario</td><td>Não</td></tr></tbody>
+  </table>
+  <table class="subListagem">
+    <caption>Alterações Ocorridas no Processo</caption>
+    <thead><tr><th>Data</th><th>Usuário</th><th>Status</th><th>Obs.</th></tr></thead>
+    <tbody><tr><td>03/01/2099</td><td>USUÁRIO DE TESTE</td><td>ATIVO</td><td>Teste.</td></tr></tbody>
+  </table>
+  <table class="subListagem">
+    <caption>Arquivos anexados ao Processo</caption>
+    <thead><tr><th>Nome</th><th>Descrição</th></tr></thead>
+    <tbody><tr><td><a href="/public/arquivo/1">arquivo.txt</a></td><td>Anexo sintético</td></tr></tbody>
+  </table>
+</td></tr></tbody></table>
+</body></html>

--- a/tests/fixtures/sipac_process.html
+++ b/tests/fixtures/sipac_process.html
@@ -25,7 +25,7 @@
     <thead><tr><th>Ordem</th><th>Documento (Espécie)</th><th>Data do Documento</th><th>Origem</th><th>Natureza</th><th></th><th></th></tr></thead>
     <tbody>
       <tr><td>1</td><td>OFÍCIO</td><td>01/01/2099</td><td>TESTE (00.00.00)</td><td>OSTENSIVO</td><td><a href="/public/verArquivoDocumento?idArquivo=1"><img alt="Visualizar Documento"></a></td><td></td></tr>
-      <tr><td>2</td><td>ANEXO</td><td>02/01/2099</td><td>TESTE (00.00.00)</td><td>RESTRITO</td><td><a href="#"><img alt="Visualizar Documento"></a></td><td></td></tr>
+      <tr><td>2</td><td>DESPACHO</td><td>02/01/2099</td><td>TESTE (00.00.00)</td><td>OSTENSIVO</td><td><a href="#" onclick="window.open('/public/jsp/processos/documento_visualizacao.jsf?idDoc=2','','width=800,height=600, scrollbars');"><img alt="Visualizar Documento"></a></td><td></td></tr>
     </tbody>
   </table>
   <table class="subListagem">

--- a/tests/fixtures/sipac_search_form.html
+++ b/tests/fixtures/sipac_search_form.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html><body>
+<form id="processoForm" name="processoForm" method="post"
+      action="/public/jsp/processos/consulta_processo.jsf">
+  <input type="hidden" name="processoForm" value="processoForm">
+  <input type="hidden" name="aba" value="p-processos">
+  <input type="hidden" name="javax.faces.ViewState" value="j_id4">
+  <input type="text" name="RADICAL_PROTOCOLO" value="23074">
+  <input type="text" name="NUM_PROTOCOLO">
+  <input type="text" name="ANO_PROTOCOLO" value="2099">
+  <input type="text" name="DV_PROTOCOLO">
+  <input type="submit" name="processoForm:dynamic_submit" value="Consultar Processo">
+</form>
+</body></html>

--- a/tests/fixtures/sipac_search_results.html
+++ b/tests/fixtures/sipac_search_results.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html><body>
+<table class="listagem">
+  <caption>Processos Encontrados</caption>
+  <thead><tr><th>Número</th><th>Assunto</th><th>Interessado</th><th>Origem</th><th></th></tr></thead>
+  <tbody><tr>
+    <td>23074.000001/2099-10</td>
+    <td>PROCESSO SINTÉTICO PARA TESTES</td>
+    <td>UNIDADE DE TESTE</td>
+    <td>UNIDADE DE TESTE (00.00.00)</td>
+    <td><a href="/public/jsp/processos/processo_detalhado.jsf?id=123">Visualizar Processo</a></td>
+  </tr></tbody>
+</table>
+</body></html>

--- a/tests/test_mcp_sipac.py
+++ b/tests/test_mcp_sipac.py
@@ -12,6 +12,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 from sigaa import mcp_server
+from sigaa.models import SipacProcessSearchPage, SipacProcessSearchResult
 from sigaa.parsers.sipac import parse_public_process
 
 
@@ -27,6 +28,7 @@ def _process():
 
 def test_mcp_registers_public_sipac_process_tool():
     assert "sipac_get_public_process" in mcp_server.mcp._tool_manager._tools
+    assert "sipac_search_public_processes" in mcp_server.mcp._tool_manager._tools
 
 
 def test_mcp_public_process_uses_shared_contract_without_credentials(monkeypatch):
@@ -53,6 +55,46 @@ def test_mcp_public_process_errors_are_tool_errors():
         mcp_server.sipac_get_public_process("invalid")
 
 
+def test_mcp_public_search_uses_shared_contract(monkeypatch):
+    expected_page = SipacProcessSearchPage(
+        query_type="identifier",
+        query="1234567",
+        page=2,
+        total_pages=3,
+        total_results=31,
+        results=[
+            SipacProcessSearchResult(
+                number="23074.000001/2099-10",
+                subject="TEST",
+                interested_parties=["JANE"],
+                origin_unit="UNIT",
+                public_url="https://sipac.ufpb.br/public/process/1",
+            )
+        ],
+    )
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def search_public_processes(self, *, name, identifier, page):
+            assert (name, identifier, page) == (None, "1234567", 2)
+            return expected_page
+
+    monkeypatch.setattr(mcp_server, "SipacClient", FakeClient)
+    data = mcp_server.sipac_search_public_processes(identifier="1234567", page=2)
+    assert data["pagination"]["page"] == 2
+    assert data["results"][0]["number"] == "23074.000001/2099-10"
+
+
+def test_mcp_public_search_rejects_ambiguous_criteria():
+    with pytest.raises(ToolError, match="exactly one"):
+        mcp_server.sipac_search_public_processes()
+
+
 def test_mcp_stdio_exposes_public_sipac_process_schema_and_validation():
     async def exercise_server():
         environment = dict(os.environ)
@@ -72,6 +114,12 @@ def test_mcp_stdio_exposes_public_sipac_process_schema_and_validation():
                 tool = tools["sipac_get_public_process"]
                 assert set(tool.inputSchema["properties"]) == {"number"}
                 assert tool.inputSchema["required"] == ["number"]
+                search = tools["sipac_search_public_processes"]
+                assert set(search.inputSchema["properties"]) == {
+                    "name",
+                    "identifier",
+                    "page",
+                }
 
                 invalid = await session.call_tool(
                     "sipac_get_public_process", {"number": "invalid"}

--- a/tests/test_mcp_sipac.py
+++ b/tests/test_mcp_sipac.py
@@ -1,0 +1,84 @@
+import asyncio
+import os
+from pathlib import Path
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from sigaa import mcp_server
+from sigaa.parsers.sipac import parse_public_process
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sipac_process.html"
+
+
+def _process():
+    return parse_public_process(
+        FIXTURE.read_text(encoding="utf-8"),
+        public_url="https://sipac.ufpb.br/public/jsp/processos/processo_detalhado.jsf?id=123",
+    )
+
+
+def test_mcp_registers_public_sipac_process_tool():
+    assert "sipac_get_public_process" in mcp_server.mcp._tool_manager._tools
+
+
+def test_mcp_public_process_uses_shared_contract_without_credentials(monkeypatch):
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_public_process(self, number):
+            assert number == "23074.000001/2099-10"
+            return _process()
+
+    monkeypatch.setattr(mcp_server, "SipacClient", FakeClient)
+
+    data = mcp_server.sipac_get_public_process("23074.000001/2099-10")
+    assert data["source"] == "sipac_ufpb_public_portal"
+    assert data["movements"][0]["destination_unit"] == "DESTINO"
+
+
+def test_mcp_public_process_errors_are_tool_errors():
+    with pytest.raises(ToolError, match="invalid SIPAC process number"):
+        mcp_server.sipac_get_public_process("invalid")
+
+
+def test_mcp_stdio_exposes_public_sipac_process_schema_and_validation():
+    async def exercise_server():
+        environment = dict(os.environ)
+        environment.pop("SIGAA_USER", None)
+        environment.pop("SIGAA_PASS", None)
+        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "sigaa.mcp_server"],
+            env=environment,
+        )
+
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                tools = {tool.name: tool for tool in (await session.list_tools()).tools}
+                tool = tools["sipac_get_public_process"]
+                assert set(tool.inputSchema["properties"]) == {"number"}
+                assert tool.inputSchema["required"] == ["number"]
+
+                invalid = await session.call_tool(
+                    "sipac_get_public_process", {"number": "invalid"}
+                )
+                assert invalid.isError is True
+                assert "invalid SIPAC process number" in " ".join(
+                    getattr(item, "text", "") for item in invalid.content
+                )
+
+    asyncio.run(exercise_server())

--- a/tests/test_sipac_cli.py
+++ b/tests/test_sipac_cli.py
@@ -1,0 +1,71 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from sigaa import cli as cli_module
+from sigaa.parsers.sipac import parse_public_process
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sipac_process.html"
+
+
+def _process():
+    return parse_public_process(
+        FIXTURE.read_text(encoding="utf-8"),
+        public_url="https://sipac.ufpb.br/public/jsp/processos/processo_detalhado.jsf?id=123",
+    )
+
+
+def test_cli_registers_nested_public_process_command():
+    args = cli_module._build_parser().parse_args(
+        ["sipac", "process", "23074.000001/2099-10"]
+    )
+
+    assert args.number == "23074.000001/2099-10"
+    assert args.json is False
+
+
+def test_cli_public_process_json_does_not_resolve_credentials(monkeypatch, capsys):
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_public_process(self, number):
+            assert number == "23074.000001/2099-10"
+            return _process()
+
+    monkeypatch.setattr(cli_module, "SipacClient", FakeClient)
+    settings = SimpleNamespace(resolve_password=lambda: (_ for _ in ()).throw(AssertionError))
+    args = cli_module._build_parser().parse_args(
+        ["sipac", "process", "23074.000001/2099-10", "--json"]
+    )
+
+    assert cli_module._cmd_sipac_process(args, settings) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert data["number"] == "23074.000001/2099-10"
+    assert data["documents"][0]["download_url"].startswith("https://sipac.ufpb.br/")
+
+
+def test_cli_main_public_process_does_not_construct_settings(monkeypatch, capsys):
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def get_public_process(self, number):
+            return _process()
+
+    monkeypatch.setattr(cli_module, "SipacClient", FakeClient)
+    monkeypatch.setattr(
+        cli_module,
+        "Settings",
+        lambda: (_ for _ in ()).throw(AssertionError("settings must stay untouched")),
+    )
+
+    assert cli_module.main(["sipac", "process", "23074.000001/2099-10"]) == 0
+    assert "PROCESSO SINTÉTICO PARA TESTES" in capsys.readouterr().out

--- a/tests/test_sipac_cli.py
+++ b/tests/test_sipac_cli.py
@@ -2,7 +2,10 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from sigaa import cli as cli_module
+from sigaa.models import SipacProcessSearchPage, SipacProcessSearchResult
 from sigaa.parsers.sipac import parse_public_process
 
 
@@ -69,3 +72,61 @@ def test_cli_main_public_process_does_not_construct_settings(monkeypatch, capsys
 
     assert cli_module.main(["sipac", "process", "23074.000001/2099-10"]) == 0
     assert "PROCESSO SINTÉTICO PARA TESTES" in capsys.readouterr().out
+
+
+def _search_page():
+    return SipacProcessSearchPage(
+        query_type="name",
+        query="JANE EXAMPLE",
+        page=1,
+        total_pages=2,
+        total_results=16,
+        results=[
+            SipacProcessSearchResult(
+                number="23074.000001/2099-10",
+                subject="PROCESSO SINTÉTICO",
+                interested_parties=["JANE EXAMPLE"],
+                origin_unit="UNIDADE DE TESTE",
+                public_url=(
+                    "https://sipac.ufpb.br/public/jsp/processos/"
+                    "processo_detalhado.jsf?id=123"
+                ),
+            )
+        ],
+    )
+
+
+def test_cli_search_requires_exactly_one_criterion():
+    parser = cli_module._build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["sipac", "search"])
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["sipac", "search", "--name", "Jane", "--identifier", "123"]
+        )
+
+
+def test_cli_search_json_uses_shared_contract_without_settings(monkeypatch, capsys):
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def search_public_processes(self, *, name, identifier, page):
+            assert (name, identifier, page) == ("JANE EXAMPLE", None, 1)
+            return _search_page()
+
+    monkeypatch.setattr(cli_module, "SipacClient", FakeClient)
+    monkeypatch.setattr(
+        cli_module, "Settings", lambda: (_ for _ in ()).throw(AssertionError)
+    )
+    assert (
+        cli_module.main(["sipac", "search", "--name", "JANE EXAMPLE", "--json"])
+        == 0
+    )
+    data = json.loads(capsys.readouterr().out)
+    assert data["query"] == {"type": "name", "value": "JANE EXAMPLE"}
+    assert data["pagination"]["total_results"] == 16
+    assert data["results"][0]["number"] == "23074.000001/2099-10"

--- a/tests/test_sipac_client.py
+++ b/tests/test_sipac_client.py
@@ -1,10 +1,15 @@
-from collections import OrderedDict
 from pathlib import Path
 
 import httpx
 import pytest
 
-from sigaa.sipac import SipacClient, SipacProcessNotFound, public_process_to_dict
+from sigaa.parsers.sipac import SipacParseError
+from sigaa.sipac import (
+    PROCESS_SEARCH_URL,
+    SipacClient,
+    SipacProcessNotFound,
+    public_process_to_dict,
+)
 
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -40,12 +45,30 @@ def test_client_replays_public_get_post_get_flow_without_credentials():
 def test_client_reports_a_missing_process():
     def handler(request: httpx.Request) -> httpx.Response:
         name = "sipac_search_form.html" if request.method == "GET" else "sipac_search_results.html"
-        text = _fixture(name).replace("23074.000001/2099-10", "23074.999999/2099-99")
+        if request.method == "GET":
+            text = _fixture(name)
+        else:
+            text = (
+                "<html><body>Nenhum processo encontrado de acordo com os "
+                "parâmetros de busca passados.</body></html>"
+            )
         return httpx.Response(200, text=text)
 
     raw = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
     with SipacClient(raw) as client:
         with pytest.raises(SipacProcessNotFound, match="was not found"):
+            client.get_public_process("23074.000001/2099-10")
+
+
+def test_client_does_not_report_unexpected_result_html_as_missing():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        return httpx.Response(200, text="<html><body>Maintenance</body></html>")
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    with SipacClient(raw, min_request_interval=0) as client:
+        with pytest.raises(SipacParseError, match="matching row or empty marker"):
             client.get_public_process("23074.000001/2099-10")
 
 
@@ -110,30 +133,8 @@ def test_client_retries_transient_responses_with_bounded_backoff():
 
 def test_client_respects_retry_after_and_does_not_retry_bare_429():
     attempts = 0
-    sleeps: list[float] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            return httpx.Response(429, headers={"Retry-After": "2"})
-        return httpx.Response(429)
-
-    raw = httpx.Client(transport=httpx.MockTransport(handler))
-    with SipacClient(
-        raw, min_request_interval=0, retry_backoff=0.25, sleep=sleeps.append
-    ) as client:
-        with pytest.raises(httpx.HTTPStatusError):
-            client.get_public_process("23074.000001/2099-10")
-
-    assert attempts == 2
-    assert sleeps == [2.0]
-
-
-def test_client_rate_limits_requests_and_reuses_short_lived_cache():
     now = 0.0
     sleeps: list[float] = []
-    requests: list[httpx.Request] = []
 
     def clock() -> float:
         return now
@@ -144,6 +145,88 @@ def test_client_rate_limits_requests_and_reuses_short_lived_cache():
         now += delay
 
     def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "2"})
+        return httpx.Response(429)
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    with SipacClient(
+        raw,
+        clock=clock,
+        min_request_interval=0,
+        retry_backoff=0.25,
+        sleep=sleep,
+    ) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            client.get_public_process("23074.000001/2099-10")
+
+    assert attempts == 2
+    assert sleeps == pytest.approx([2.0], abs=0.01)
+
+
+def test_client_does_not_retry_before_a_long_retry_after_expires():
+    now = 0.0
+    sleeps: list[float] = []
+    attempts = 0
+
+    def clock() -> float:
+        return now
+
+    def sleep(delay: float) -> None:
+        nonlocal now
+        sleeps.append(delay)
+        now += delay
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "120"})
+        return httpx.Response(200, text="ok")
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    with SipacClient(
+        raw,
+        clock=clock,
+        sleep=sleep,
+        min_request_interval=0,
+        max_retries=2,
+    ) as client:
+        first = client._request("GET", PROCESS_SEARCH_URL)
+        assert first.status_code == 429
+        assert attempts == 1
+        second = client._request("GET", PROCESS_SEARCH_URL)
+
+    assert second.status_code == 200
+    assert attempts == 2
+    assert sleeps == [120.0]
+
+
+@pytest.mark.parametrize("retry_after", ["1e309", "inf", "3601", "12.5"])
+def test_invalid_or_excessive_retry_after_does_not_poison_the_limiter(retry_after):
+    attempts = 0
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        return httpx.Response(429, headers={"Retry-After": retry_after})
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    with SipacClient(raw, min_request_interval=0, sleep=sleeps.append) as client:
+        response = client._request("GET", PROCESS_SEARCH_URL)
+
+    assert response.status_code == 429
+    assert attempts == 1
+    assert sleeps == []
+
+
+def test_client_rate_limits_each_request_without_retaining_results():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
         if request.method == "GET" and "consulta_processo" in request.url.path:
             return httpx.Response(200, text=_fixture("sipac_search_form.html"))
@@ -152,24 +235,8 @@ def test_client_rate_limits_requests_and_reuses_short_lived_cache():
         return httpx.Response(200, text=_fixture("sipac_process.html"))
 
     raw = httpx.Client(transport=httpx.MockTransport(handler))
-    cache = OrderedDict()
-    with SipacClient(
-        raw,
-        clock=clock,
-        sleep=sleep,
-        min_request_interval=1.0,
-        cache_ttl=10.0,
-        cache_max_entries=1,
-        cache=cache,
-    ) as client:
-        first = client.get_public_process("23074.000001/2099-10")
-        first.status = "MUTATED"
-        cached = client.get_public_process("23074.000001/2099-10")
-        now += 11.0
-        refreshed = client.get_public_process("23074.000001/2099-10")
+    with SipacClient(raw, min_request_interval=0) as client:
+        client.get_public_process("23074.000001/2099-10")
+        client.get_public_process("23074.000001/2099-10")
 
     assert len(requests) == 6
-    assert sleeps == [1.0, 1.0, 1.0, 1.0]
-    assert cached.status == "ATIVO"
-    assert refreshed.status == "ATIVO"
-    assert len(cache) == 1

--- a/tests/test_sipac_client.py
+++ b/tests/test_sipac_client.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+import httpx
+import pytest
+
+from sigaa.sipac import SipacClient, SipacProcessNotFound, public_process_to_dict
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_client_replays_public_get_post_get_flow_without_credentials():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET" and "consulta_processo" in request.url.path:
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        if request.method == "POST":
+            assert b"NUM_PROTOCOLO=000001" in request.content
+            return httpx.Response(200, text=_fixture("sipac_search_results.html"))
+        return httpx.Response(200, text=_fixture("sipac_process.html"))
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    with SipacClient(raw) as client:
+        process = client.get_public_process("23074.000001/2099-10")
+
+    assert [request.method for request in requests] == ["GET", "POST", "GET"]
+    data = public_process_to_dict(process)
+    assert data["schema_version"] == 1
+    assert data["source"] == "sipac_ufpb_public_portal"
+    assert data["documents"][0]["kind"] == "OFÍCIO"
+
+
+def test_client_reports_a_missing_process():
+    def handler(request: httpx.Request) -> httpx.Response:
+        name = "sipac_search_form.html" if request.method == "GET" else "sipac_search_results.html"
+        text = _fixture(name).replace("23074.000001/2099-10", "23074.999999/2099-99")
+        return httpx.Response(200, text=text)
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    with SipacClient(raw) as client:
+        with pytest.raises(SipacProcessNotFound, match="was not found"):
+            client.get_public_process("23074.000001/2099-10")

--- a/tests/test_sipac_client.py
+++ b/tests/test_sipac_client.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from pathlib import Path
 
 import httpx
@@ -46,3 +47,129 @@ def test_client_reports_a_missing_process():
     with SipacClient(raw) as client:
         with pytest.raises(SipacProcessNotFound, match="was not found"):
             client.get_public_process("23074.000001/2099-10")
+
+
+def test_client_rejects_redirects_outside_the_public_https_host():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(302, headers={"Location": "http://127.0.0.1/admin"})
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    with SipacClient(raw, min_request_interval=0) as client:
+        with pytest.raises(ValueError, match="outside its public HTTPS host"):
+            client.get_public_process("23074.000001/2099-10")
+
+
+def test_client_follows_same_host_https_redirects_manually():
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/redirected-form":
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        if request.method == "GET" and "consulta_processo" in request.url.path:
+            return httpx.Response(302, headers={"Location": "/redirected-form"})
+        if request.method == "POST":
+            return httpx.Response(200, text=_fixture("sipac_search_results.html"))
+        return httpx.Response(200, text=_fixture("sipac_process.html"))
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler), follow_redirects=True)
+    with SipacClient(raw, min_request_interval=0) as client:
+        process = client.get_public_process("23074.000001/2099-10")
+
+    assert process.number == "23074.000001/2099-10"
+    assert requests[1].url == httpx.URL("https://sipac.ufpb.br/redirected-form")
+
+
+def test_client_retries_transient_responses_with_bounded_backoff():
+    attempts = 0
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        if request.method == "GET" and "consulta_processo" in request.url.path:
+            attempts += 1
+            if attempts < 3:
+                return httpx.Response(503)
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        if request.method == "POST":
+            return httpx.Response(200, text=_fixture("sipac_search_results.html"))
+        return httpx.Response(200, text=_fixture("sipac_process.html"))
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    with SipacClient(
+        raw,
+        min_request_interval=0,
+        retry_backoff=0.5,
+        sleep=sleeps.append,
+    ) as client:
+        client.get_public_process("23074.000001/2099-10")
+
+    assert attempts == 3
+    assert sleeps == [0.5, 1.0]
+
+
+def test_client_respects_retry_after_and_does_not_retry_bare_429():
+    attempts = 0
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(429, headers={"Retry-After": "2"})
+        return httpx.Response(429)
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    with SipacClient(
+        raw, min_request_interval=0, retry_backoff=0.25, sleep=sleeps.append
+    ) as client:
+        with pytest.raises(httpx.HTTPStatusError):
+            client.get_public_process("23074.000001/2099-10")
+
+    assert attempts == 2
+    assert sleeps == [2.0]
+
+
+def test_client_rate_limits_requests_and_reuses_short_lived_cache():
+    now = 0.0
+    sleeps: list[float] = []
+    requests: list[httpx.Request] = []
+
+    def clock() -> float:
+        return now
+
+    def sleep(delay: float) -> None:
+        nonlocal now
+        sleeps.append(delay)
+        now += delay
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "GET" and "consulta_processo" in request.url.path:
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        if request.method == "POST":
+            return httpx.Response(200, text=_fixture("sipac_search_results.html"))
+        return httpx.Response(200, text=_fixture("sipac_process.html"))
+
+    raw = httpx.Client(transport=httpx.MockTransport(handler))
+    cache = OrderedDict()
+    with SipacClient(
+        raw,
+        clock=clock,
+        sleep=sleep,
+        min_request_interval=1.0,
+        cache_ttl=10.0,
+        cache_max_entries=1,
+        cache=cache,
+    ) as client:
+        first = client.get_public_process("23074.000001/2099-10")
+        first.status = "MUTATED"
+        cached = client.get_public_process("23074.000001/2099-10")
+        now += 11.0
+        refreshed = client.get_public_process("23074.000001/2099-10")
+
+    assert len(requests) == 6
+    assert sleeps == [1.0, 1.0, 1.0, 1.0]
+    assert cached.status == "ATIVO"
+    assert refreshed.status == "ATIVO"
+    assert len(cache) == 1

--- a/tests/test_sipac_parser.py
+++ b/tests/test_sipac_parser.py
@@ -55,9 +55,37 @@ def test_parse_public_process_returns_all_public_sections():
     assert process.documents[0].download_url == (
         "https://sipac.ufpb.br/public/verArquivoDocumento?idArquivo=1"
     )
-    assert process.documents[1].download_url is None
+    assert process.documents[1].download_url == (
+        "https://sipac.ufpb.br/public/jsp/processos/"
+        "documento_visualizacao.jsf?idDoc=2"
+    )
     assert process.movements[0].urgent is False
     assert process.status_changes[0].note == "Teste."
     assert process.attached_files[0].download_url == (
         "https://sipac.ufpb.br/public/arquivo/1"
     )
+
+
+@pytest.mark.parametrize(
+    "unsafe_onclick",
+    [
+        "window.open('/public/jsp/processos/documento_visualizacao.jsf?idDoc=invalid')",
+        "window.open('https://example.com/public/jsp/processos/"
+        "documento_visualizacao.jsf?idDoc=2')",
+    ],
+)
+def test_parse_public_process_rejects_unsafe_document_view_onclick(unsafe_onclick):
+    html = (FIXTURES / "sipac_process.html").read_text(encoding="utf-8")
+    html = html.replace(
+        "window.open('/public/jsp/processos/documento_visualizacao.jsf?idDoc=2',"
+        "'','width=800,height=600, scrollbars');",
+        unsafe_onclick,
+    )
+
+    process = parse_public_process(
+        html,
+        public_url="https://sipac.ufpb.br/public/jsp/processos/"
+        "processo_detalhado.jsf?id=123",
+    )
+
+    assert process.documents[1].download_url is None

--- a/tests/test_sipac_parser.py
+++ b/tests/test_sipac_parser.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from sigaa.parsers.sipac import (
+    SipacParseError,
     build_process_search_payload,
     normalize_process_number,
     parse_process_detail_url,
@@ -37,7 +38,14 @@ def test_parse_search_result_selects_the_matching_public_detail_url():
     assert parse_process_detail_url(html, "23074.000001/2099-10") == (
         "https://sipac.ufpb.br/public/jsp/processos/processo_detalhado.jsf?id=123"
     )
-    assert parse_process_detail_url(html, "23074.999999/2099-99") is None
+    with pytest.raises(SipacParseError, match="matching row or empty marker"):
+        parse_process_detail_url(html, "23074.999999/2099-99")
+
+    empty = (
+        "<html><body>Nenhum processo encontrado de acordo com os parâmetros "
+        "de busca passados.</body></html>"
+    )
+    assert parse_process_detail_url(empty, "23074.999999/2099-99") is None
 
 
 def test_parse_public_process_returns_all_public_sections():

--- a/tests/test_sipac_parser.py
+++ b/tests/test_sipac_parser.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import pytest
+
+from sigaa.parsers.sipac import (
+    build_process_search_payload,
+    normalize_process_number,
+    parse_process_detail_url,
+    parse_public_process,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def test_normalize_process_number_accepts_whitespace_and_rejects_other_shapes():
+    assert normalize_process_number(" 23074.000001 / 2099 - 10 ") == "23074.000001/2099-10"
+    with pytest.raises(ValueError, match="00000.000000/0000-00"):
+        normalize_process_number("23074-1")
+
+
+def test_build_search_payload_replays_dynamic_jsf_fields():
+    html = (FIXTURES / "sipac_search_form.html").read_text(encoding="utf-8")
+    payload = build_process_search_payload(html, "23074.000001/2099-10")
+
+    assert payload["javax.faces.ViewState"] == "j_id4"
+    assert payload["processoForm:dynamic_submit"] == "Consultar Processo"
+    assert payload["RADICAL_PROTOCOLO"] == "23074"
+    assert payload["NUM_PROTOCOLO"] == "000001"
+    assert payload["ANO_PROTOCOLO"] == "2099"
+    assert payload["DV_PROTOCOLO"] == "10"
+
+
+def test_parse_search_result_selects_the_matching_public_detail_url():
+    html = (FIXTURES / "sipac_search_results.html").read_text(encoding="utf-8")
+
+    assert parse_process_detail_url(html, "23074.000001/2099-10") == (
+        "https://sipac.ufpb.br/public/jsp/processos/processo_detalhado.jsf?id=123"
+    )
+    assert parse_process_detail_url(html, "23074.999999/2099-99") is None
+
+
+def test_parse_public_process_returns_all_public_sections():
+    html = (FIXTURES / "sipac_process.html").read_text(encoding="utf-8")
+    process = parse_public_process(
+        html,
+        public_url="https://sipac.ufpb.br/public/jsp/processos/processo_detalhado.jsf?id=123",
+    )
+
+    assert process.number == "23074.000001/2099-10"
+    assert process.detailed_subject == "PROCESSO SINTÉTICO PARA TESTES"
+    assert process.status == "ATIVO"
+    assert process.interested_parties[0].name == "UNIDADE DE TESTE"
+    assert len(process.documents) == 2
+    assert process.documents[0].download_url == (
+        "https://sipac.ufpb.br/public/verArquivoDocumento?idArquivo=1"
+    )
+    assert process.documents[1].download_url is None
+    assert process.movements[0].urgent is False
+    assert process.status_changes[0].note == "Teste."
+    assert process.attached_files[0].download_url == (
+        "https://sipac.ufpb.br/public/arquivo/1"
+    )

--- a/tests/test_sipac_search_client.py
+++ b/tests/test_sipac_search_client.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from pathlib import Path
 
 import httpx
@@ -17,7 +16,6 @@ def _client(handler):
     return SipacClient(
         httpx.Client(transport=httpx.MockTransport(handler)),
         min_request_interval=0,
-        cache=OrderedDict(),
     )
 
 
@@ -65,42 +63,47 @@ def test_client_fetches_only_the_requested_second_page():
     assert page.page == 2
 
 
-def test_client_search_cache_avoids_a_second_portal_round_trip():
+def test_name_search_does_not_retain_results_between_calls():
     calls = 0
 
     def handler(request):
         nonlocal calls
         calls += 1
-        name = "sipac_search_form.html" if request.method == "GET" else "sipac_interested_results.html"
+        name = (
+            "sipac_search_form.html"
+            if request.method == "GET"
+            else "sipac_interested_results.html"
+        )
         return httpx.Response(200, text=_fixture(name))
 
     with _client(handler) as client:
         first = client.search_public_processes(name="JANE EXAMPLE")
         second = client.search_public_processes(name="JANE EXAMPLE")
 
-    assert calls == 2
+    assert calls == 4
     assert first == second
     assert first is not second
 
 
-def test_identifier_search_is_never_cached_in_shared_or_injected_memory():
+def test_identifier_search_does_not_retain_results_between_calls():
     calls = 0
-    cache = OrderedDict()
 
     def handler(request):
         nonlocal calls
         calls += 1
-        name = "sipac_search_form.html" if request.method == "GET" else "sipac_interested_results.html"
+        name = (
+            "sipac_search_form.html"
+            if request.method == "GET"
+            else "sipac_interested_results.html"
+        )
         return httpx.Response(200, text=_fixture(name))
 
     client = SipacClient(
         httpx.Client(transport=httpx.MockTransport(handler)),
         min_request_interval=0,
-        cache=cache,
     )
     with client:
         client.search_public_processes(identifier="1234567")
         client.search_public_processes(identifier="1234567")
 
     assert calls == 4
-    assert cache == {}

--- a/tests/test_sipac_search_client.py
+++ b/tests/test_sipac_search_client.py
@@ -1,0 +1,106 @@
+from collections import OrderedDict
+from pathlib import Path
+
+import httpx
+
+from sigaa.sipac import SipacClient, public_process_search_to_dict
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def _client(handler):
+    return SipacClient(
+        httpx.Client(transport=httpx.MockTransport(handler)),
+        min_request_interval=0,
+        cache=OrderedDict(),
+    )
+
+
+def test_client_searches_by_name_and_returns_shared_contract():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        body = request.content.decode()
+        assert "tipo_consulta=200" in body
+        assert "INTERESSADO=JANE+EXAMPLE" in body
+        return httpx.Response(200, text=_fixture("sipac_interested_results.html"))
+
+    with _client(handler) as client:
+        page = client.search_public_processes(name="JANE EXAMPLE")
+
+    assert [request.method for request in requests] == ["GET", "POST"]
+    data = public_process_search_to_dict(page)
+    assert data["query"] == {"type": "name", "value": "JANE EXAMPLE"}
+    assert data["pagination"]["page_size"] == 15
+    assert data["pagination"]["returned_results"] == 1
+
+
+def test_client_fetches_only_the_requested_second_page():
+    requests = []
+
+    def handler(request):
+        requests.append(request)
+        if len(requests) == 1:
+            return httpx.Response(200, text=_fixture("sipac_search_form.html"))
+        if len(requests) == 2:
+            assert "tipo_consulta=300" in request.content.decode()
+            return httpx.Response(200, text=_fixture("sipac_interested_results.html"))
+        assert request.url.path.endswith("/processos.jsf")
+        assert "documentoForm%3Adynamic_page=1" in request.content.decode()
+        return httpx.Response(200, text=_fixture("sipac_interested_results.html"))
+
+    with _client(handler) as client:
+        page = client.search_public_processes(identifier="1234567", page=2)
+
+    assert len(requests) == 3
+    assert page.query_type == "identifier"
+    assert page.page == 2
+
+
+def test_client_search_cache_avoids_a_second_portal_round_trip():
+    calls = 0
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        name = "sipac_search_form.html" if request.method == "GET" else "sipac_interested_results.html"
+        return httpx.Response(200, text=_fixture(name))
+
+    with _client(handler) as client:
+        first = client.search_public_processes(name="JANE EXAMPLE")
+        second = client.search_public_processes(name="JANE EXAMPLE")
+
+    assert calls == 2
+    assert first == second
+    assert first is not second
+
+
+def test_identifier_search_is_never_cached_in_shared_or_injected_memory():
+    calls = 0
+    cache = OrderedDict()
+
+    def handler(request):
+        nonlocal calls
+        calls += 1
+        name = "sipac_search_form.html" if request.method == "GET" else "sipac_interested_results.html"
+        return httpx.Response(200, text=_fixture(name))
+
+    client = SipacClient(
+        httpx.Client(transport=httpx.MockTransport(handler)),
+        min_request_interval=0,
+        cache=cache,
+    )
+    with client:
+        client.search_public_processes(identifier="1234567")
+        client.search_public_processes(identifier="1234567")
+
+    assert calls == 4
+    assert cache == {}

--- a/tests/test_sipac_search_parser.py
+++ b/tests/test_sipac_search_parser.py
@@ -1,0 +1,93 @@
+from pathlib import Path
+
+import pytest
+
+from sigaa.parsers.sipac import (
+    SipacParseError,
+    build_interested_search_payload,
+    build_results_page_request,
+    normalize_interested_search,
+    parse_process_search_page,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _fixture(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+def test_interested_search_payload_supports_name_and_identifier():
+    html = _fixture("sipac_search_form.html")
+    kind, query, payload = build_interested_search_payload(html, name="  Jane   Example ")
+    assert (kind, query) == ("name", "Jane Example")
+    assert payload["tipo_consulta"] == "200"
+    assert payload["INTERESSADO"] == "Jane Example"
+    assert payload["CPF_CNPJ"] == ""
+
+    kind, query, payload = build_interested_search_payload(html, identifier=" 1234567 ")
+    assert (kind, query) == ("identifier", "1234567")
+    assert payload["tipo_consulta"] == "300"
+    assert payload["INTERESSADO"] == ""
+    assert payload["CPF_CNPJ"] == "1234567"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({}, "exactly one"),
+        ({"name": "Jane", "identifier": "123"}, "exactly one"),
+        ({"name": " x "}, "3 to 200"),
+        ({"identifier": "123.456"}, "digits only"),
+        ({"identifier": "1" * 15}, "digits only"),
+    ],
+)
+def test_interested_search_rejects_ambiguous_or_unsafe_input(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        normalize_interested_search(**kwargs)
+
+
+def test_parse_interested_results_and_pagination_metadata():
+    page = parse_process_search_page(
+        _fixture("sipac_interested_results.html"),
+        query_type="name",
+        query="JANE EXAMPLE",
+        page=1,
+    )
+    assert page.total_results == 31
+    assert page.total_pages == 3
+    assert page.results[0].number == "23074.000001/2099-10"
+    assert page.results[0].interested_parties == ["JANE EXAMPLE", "OTHER UNIT"]
+    assert page.results[0].public_url.endswith("processo_detalhado.jsf?id=123")
+
+
+def test_build_results_page_request_replays_dynamic_jsf_fields():
+    url, payload = build_results_page_request(
+        _fixture("sipac_interested_results.html"), 2
+    )
+    assert url == "https://sipac.ufpb.br/public/jsp/processos/processos.jsf"
+    assert payload["javax.faces.ViewState"] == "j_id4"
+    assert payload["documentoForm:dynamic_page"] == "1"
+
+
+def test_pagination_rejects_out_of_range_and_external_action():
+    html = _fixture("sipac_interested_results.html")
+    with pytest.raises(ValueError, match="between 1 and 3"):
+        build_results_page_request(html, 4)
+    with pytest.raises(SipacParseError, match="not safe"):
+        build_results_page_request(html.replace(
+            "/public/jsp/processos/processos.jsf", "https://evil.example/processos.jsf"
+        ), 2)
+
+
+def test_empty_search_page_is_a_valid_zero_result_contract():
+    page = parse_process_search_page(
+        "<html><body>0 Registro(s) Encontrado(s)</body></html>",
+        query_type="name",
+        query="NOBODY",
+        page=1,
+    )
+    assert page.total_results == 0
+    assert page.total_pages == 0
+    assert page.results == []

--- a/tests/test_sipac_search_parser.py
+++ b/tests/test_sipac_search_parser.py
@@ -83,7 +83,10 @@ def test_pagination_rejects_out_of_range_and_external_action():
 
 def test_empty_search_page_is_a_valid_zero_result_contract():
     page = parse_process_search_page(
-        "<html><body>0 Registro(s) Encontrado(s)</body></html>",
+        (
+            "<html><body><center>Nenhum processo encontrado de acordo com os "
+            "parâmetros de busca passados.</center></body></html>"
+        ),
         query_type="name",
         query="NOBODY",
         page=1,
@@ -91,3 +94,22 @@ def test_empty_search_page_is_a_valid_zero_result_contract():
     assert page.total_results == 0
     assert page.total_pages == 0
     assert page.results == []
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        "<html><body>Manutenção temporária</body></html>",
+        "<html><body><form id='loginForm'></form></body></html>",
+        "<html><body>0 Registro(s) Encontrado(s)</body></html>",
+        "<html><body>2 Registro(s) Encontrado(s)</body></html>",
+    ],
+)
+def test_search_page_does_not_misreport_portal_failures_as_zero_results(html):
+    with pytest.raises(SipacParseError):
+        parse_process_search_page(
+            html,
+            query_type="name",
+            query="JANE EXAMPLE",
+            page=1,
+        )


### PR DESCRIPTION
## Why

UFPB administrative processes still required manual navigation in SIPAC. This PR adds a read-only integration with the public portal for exact process lookup and discovery by interested party.

No SIPAC login is required. Stored SIGAA credentials are never read.

## What changed

- Exact lookup by full process number
- Paginated search by interested-party name or identifier (registration, CPF, or CNPJ)
- CLI commands:
  - `sigaa sipac process <number>`
  - `sigaa sipac search --name "..." [--page N]`
  - `sigaa sipac search --identifier "..." [--page N]`
- MCP tools:
  - `sipac_get_public_process(number)`
  - `sipac_search_public_processes(name?, identifier?, page=1)`
- Shared `schema_version: 1` JSON contracts
- Structured general data, interested parties, documents, public links, movements, status changes, attachments, search rows, and pagination
- Dedicated guide covering use cases, fields, examples, limits, errors, and privacy

## Examples

```bash
sigaa sipac process 23074.056437/2026-26 --json
sigaa sipac search --name "Gilberto Farias de Sousa Filho" --page 2 --json
sigaa sipac search --identifier "12345678901" --json
```

```json
{
  "name": "Gilberto Farias de Sousa Filho",
  "page": 1
}
```

Search accepts exactly one of `name` or `identifier` and returns one portal page at a time, up to 15 rows.

## Live verification

| Process | Status | Documents | Native public links | Movements |
|---|---:|---:|---:|---:|
| `23074.056437/2026-26` | ATIVO | 14 | 5 | 6 |
| `23074.052189/2026-68` | ATIVO | 10 | 7 | 7 |
| `23074.061283/2026-37` | ATIVO | 4 | 3 | 2 |
| `23074.061289/2026-69` | ATIVO | 4 | 3 | 2 |
| `23074.100368/2024-11` | ARQUIVADO | 3 | 2 | 2 |

Other live checks:

- Documented name example: 162 results across 11 pages
- Pages 1, 2, and 11 returned the expected distinct rows; page 12 was rejected
- Search for `RALF`: 4 rows, including `23074.100368/2024-11`
- Nonexistent name: explicit empty result (`0/0/0`)
- Nonexistent process number: explicit `SipacProcessNotFound`
- Native document links implemented through `window.open(...)` resolve correctly

Live HTML, cookies, credentials, and real identifiers were not committed.

## Reliability and security

- HTTPS-only redirects to the exact `sipac.ufpb.br` host, maximum five hops
- Shared request pacing between normal clients
- Bounded retries for transient failures
- `Retry-After` creates a shared server cooldown; long cooldowns are not retried early
- Malformed, non-finite, decimal, or excessive cooldown values cannot poison the process
- HTTP 200 maintenance/login pages are never misreported as zero results or “not found”
- Empty results require SIPAC's explicit empty-result marker
- Results are not cached or persisted after a request
- Restricted documents are not bypassed
- No creation, protocol submission, routing, or other mutation

CPF, registration numbers, and CNPJ can be personal data. Use identifier search only for a legitimate purpose and keep identifiers out of logs and shared output.

## Validation

- Full suite: `202 passed, 1 deselected`
- SIPAC-focused parser, HTTP, retry, concurrency, privacy, CLI, MCP, and stdio tests passed
- Package wheel built successfully
- `python -m compileall -q sigaa` passed
- `git diff --check` passed
- Three independent final reviews covered parser/pagination, API/docs, and security; all were clean after fixes
- GitGuardian passed on the previously published head; the latest head is awaiting its check

The deselected setup-wizard test is a pre-existing Windows path assertion unrelated to SIPAC. The repository does not currently run a Python test workflow on pull requests.

## Review focus

- JSF form replay and dynamic pagination
- Explicit empty-result detection versus unexpected HTTP 200 pages
- Safe public document-link extraction
- Redirect allowlist, retry cooldown, and request pacing
- CLI/MCP contract consistency and identifier privacy

AI assistance was used during implementation and review. All reported examples, counts, and commands were verified against the current branch.
