### PR TITLE
feat: allow configuring SIGAA HTTP timeout

### DIFF
--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -6,6 +6,8 @@ import re
 from dataclasses import replace
 from decimal import Decimal
 
+import httpx
+
 from . import config
 from .documents import (
     ATESTADO_MATRICULA,
@@ -41,8 +43,14 @@ from .parsers import transcript as transcript_parser
 
 
 class SigaaClient:
-    def __init__(self, username: str, password: str):
-        self._session = Session(username, password)
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        *,
+        timeout: float | httpx.Timeout = 30.0,
+    ):
+        self._session = Session(username, password, timeout=timeout)
         self._portal_html: str | None = None
 
     def _portal(self) -> str:

--- a/sigaa/http.py
+++ b/sigaa/http.py
@@ -31,13 +31,20 @@ class AuthError(RuntimeError):
 class Session:
     """Stateful SIGAA session. Construct with credentials, then ``login()``."""
 
-    def __init__(self, username: str, password: str, client: httpx.Client | None = None):
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        client: httpx.Client | None = None,
+        *,
+        timeout: float | httpx.Timeout = 30.0,
+    ):
         self._username = username
         self._password = password
         self._client = client or httpx.Client(
             headers={"User-Agent": config.USER_AGENT},
             follow_redirects=True,
-            timeout=30.0,
+            timeout=timeout,
         )
         self._authenticated = False
 

--- a/tests/test_http_configuration.py
+++ b/tests/test_http_configuration.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import httpx
+
+from sigaa.client import SigaaClient
+
+
+def test_sigaa_client_accepts_a_custom_http_timeout(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeHttpClient:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(httpx, "Client", FakeHttpClient)
+    timeout = httpx.Timeout(60.0, connect=10.0)
+
+    SigaaClient("student", "secret", timeout=timeout)
+
+    assert captured["timeout"] is timeout
+    assert captured["follow_redirects"] is True


### PR DESCRIPTION
## Contexto

O cliente fixava 30 segundos para toda requisição HTTP. Em períodos lentos do SIGAA, integrações com um teto global maior não conseguiam ajustar o tempo de leitura sem acessar detalhes privados do cliente.

## Mudança

- expõe timeout como parâmetro opcional de SigaaClient
- encaminha o valor para a sessão HTTP
- mantém 30 segundos como padrão retrocompatível
- aceita tanto segundos quanto httpx.Timeout para separar conexão e leitura

## Validação

- testes focados: 29 passed
- suíte completa: 203 passed; 1 falha preexistente/específica do Windows no teste de resolução de script