### PR TITLE
fix: drop license classifier superseded by license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
 keywords = ["sigaa", "ufpb", "mcp", "cli", "academic"]
 classifiers = [
     "Environment :: Console",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]


### PR DESCRIPTION
setuptools >=77 rejects the `License :: OSI Approved :: MIT License` classifier when `license = "MIT"` (PEP 639) is present in `pyproject.toml`, which breaks `uv run` source builds with `InvalidConfigError`. Drop the classifier; the SPDX license expression stays.