### PR TITLE
feat: curriculum progress (integralização) via CLI and MCP

### DIFF
--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -74,6 +74,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p_ics.add_argument("--out", help="output file (default: stdout)")
     p_ics.set_defaults(func=_cmd_ics)
 
+    p_curr = sub.add_parser("curriculo", help="curriculum progress / integralização (networked)")
+    p_curr.add_argument("--pending", action="store_true", help="only components not yet completed")
+    p_curr.add_argument("--mandatory", action="store_true", help="only mandatory components")
+    p_curr.add_argument("--json", action="store_true")
+    p_curr.set_defaults(func=_cmd_curriculo)
+
     p_hist = sub.add_parser("historico", help="download the academic transcript PDF (networked)")
     p_hist.add_argument("--out", default="historico.pdf", help="output file (default: historico.pdf)")
     p_hist.set_defaults(func=_cmd_historico)
@@ -256,6 +262,26 @@ def _cmd_ics(args, settings: Settings) -> int:
         print(f"wrote {args.out}")
     else:
         print(ics, end="")
+    return 0
+
+
+def _cmd_curriculo(args, settings: Settings) -> int:
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        print("missing credentials (set SIGAA_USER and keyring/SIGAA_PASS)", file=sys.stderr)
+        return 1
+    with SigaaClient(settings.username, password) as client:
+        components = client.list_curriculum_components()
+    if args.pending:
+        components = [c for c in components if not c.completed]
+    if args.mandatory:
+        components = [c for c in components if c.mandatory]
+    if args.json:
+        print(json.dumps([vars(c) for c in components], ensure_ascii=False, indent=1))
+        return 0
+    for c in components:
+        status = "CONCLUIDO" if c.completed else ("PENDENTE" if c.prerequisite_met else "BLOQUEADA")
+        print(f"P{c.period} {c.kind:2} {c.code:9} {c.name[:52]:52} {c.hours:3}h {status}")
     return 0
 
 

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -50,6 +50,24 @@ class SigaaClient:
         html = self._portal_menu_post("Minhas Notas")
         return grades_parser.parse_grades(html)
 
+    def get_integralizacao(self) -> dict:
+        """Curriculum progress (integralização) as raw JSON data."""
+        import json
+
+        # The dados endpoint 302s to an HTML shell unless the integralização
+        # page was opened first in this session (server-side JSF context).
+        self._session.get(config.INTEGRALIZACAO_URL)
+        text = self._session.get_json_latin1(
+            config.INTEGRALIZACAO_DADOS_URL, referer=config.INTEGRALIZACAO_URL
+        )
+        return json.loads(text)
+
+    def list_curriculum_components(self):
+        """Curriculum components with completion and prerequisite status."""
+        from .parsers import curriculo as curriculo_parser
+
+        return curriculo_parser.parse_components(self.get_integralizacao())
+
     def get_historico_pdf(self) -> bytes:
         """Download the full academic transcript (Histórico) as a PDF."""
         portal = self._portal()

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -67,3 +67,8 @@ class Settings:
             except Exception:
                 pass
         return os.environ.get("SIGAA_PASS")
+
+# Integralização (curriculum progress). The dados endpoint returns JSON, but
+# only for XHR-shaped requests, and the body is latin-1 encoded.
+INTEGRALIZACAO_URL = f"{BASE}/portal/discente/integralizacao/"
+INTEGRALIZACAO_DADOS_URL = f"{BASE}/portal/discente/integralizacao/dados/"

--- a/sigaa/http.py
+++ b/sigaa/http.py
@@ -52,6 +52,29 @@ class Session:
     def get(self, url: str) -> str:
         return self._request("GET", url)
 
+    def get_json_latin1(self, url: str, referer: str | None = None) -> str:
+        """GET a JSON endpoint that requires XHR headers and replies in latin-1.
+
+        Returns the decoded JSON text; re-logins and retries once if bounced.
+        """
+        if not self._authenticated:
+            self.login()
+        headers = {
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        if referer:
+            headers["Referer"] = referer
+        resp = self._client.get(url, headers=headers)
+        resp.raise_for_status()
+        text = resp.content.decode("latin-1")
+        if self._looks_logged_out(text):
+            self.login()
+            resp = self._client.get(url, headers=headers)
+            resp.raise_for_status()
+            text = resp.content.decode("latin-1")
+        return text
+
     def post(self, url: str, data: dict[str, str]) -> str:
         return self._request("POST", url, data=data)
 

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -382,6 +382,22 @@ def sigaa_download_historico(path: str = "historico.pdf") -> str:
 
 
 @mcp.tool()
+def sigaa_get_curriculo(pending_only: bool = False, mandatory_only: bool = False) -> list[dict]:
+    """Curriculum progress (integralização): components with completion and prereq status. Networked."""
+    settings = Settings()
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        return [{"error": "no credentials available"}]
+    with SigaaClient(settings.username, password) as client:
+        components = client.list_curriculum_components()
+    if pending_only:
+        components = [c for c in components if not c.completed]
+    if mandatory_only:
+        components = [c for c in components if c.mandatory]
+    return [vars(c) for c in components]
+
+
+@mcp.tool()
 def sigaa_sync(fetch_bodies: bool = False) -> dict:
     """Refresh from SIGAA and persist new news. The only networked tool."""
     result = run_sync(Settings(), fetch_bodies=fetch_bodies)

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -158,3 +158,18 @@ class Deadline:
     detail: str | None = None  # e.g. "em 10 dias"
     # JSON of the scraped event detail rows (Descrição, Período, ...), cached on demand.
     body: str | None = None
+
+
+@dataclass
+class CurriculumComponent:
+    """A curriculum component from the integralização report."""
+
+    code: str
+    name: str
+    kind: str  # OB / CO / CF / OP / EC
+    period: int
+    hours: int
+    mandatory: bool
+    completed: bool
+    prerequisite: str | None = None
+    prerequisite_met: bool = True

--- a/sigaa/parsers/curriculo.py
+++ b/sigaa/parsers/curriculo.py
@@ -1,0 +1,44 @@
+"""Parse the integralização JSON: curriculum components and prerequisite logic."""
+
+from __future__ import annotations
+
+import re
+
+from ..models import CurriculumComponent
+
+_CODE_RE = re.compile(r"[A-Z0-9]{7,9}")
+_SAFE_BOOL_EXPR_RE = re.compile(r"^[\sTrueFalsandor()]+$")
+
+
+def parse_components(data: dict) -> list[CurriculumComponent]:
+    done = {
+        d["codigo"] for d in data.get("disciplinas", []) if d.get("situacao") == "CONCLUIDO"
+    }
+    components = []
+    for d in data.get("disciplinas", []):
+        prereq = d.get("expressaoPreRequisito", "")
+        components.append(
+            CurriculumComponent(
+                code=d.get("codigo", ""),
+                name=d.get("nome", ""),
+                kind=d.get("tipoIntegralizacao", ""),
+                period=d.get("periodo", 0),
+                hours=d.get("cargaHoraria", 0),
+                mandatory=bool(d.get("obrigatoria")),
+                completed=d.get("situacao") == "CONCLUIDO",
+                prerequisite=prereq or None,
+                prerequisite_met=prerequisite_met(prereq, done),
+            )
+        )
+    return components
+
+
+def prerequisite_met(expression: str | None, completed_codes: set[str]) -> bool:
+    """Evaluate a SIGAA prerequisite expression like ``( A ) E ( B OU C )``."""
+    if not expression or not expression.strip():
+        return True
+    expr = _CODE_RE.sub(lambda m: str(m.group(0) in completed_codes), expression)
+    expr = expr.replace(" E ", " and ").replace(" OU ", " or ")
+    if not _SAFE_BOOL_EXPR_RE.match(expr):
+        raise ValueError(f"unparseable prerequisite expression: {expression!r}")
+    return bool(eval(expr, {"__builtins__": {}}, {}))  # noqa: S307 - vetted True/False/and/or only

--- a/tests/test_curriculo.py
+++ b/tests/test_curriculo.py
@@ -1,0 +1,38 @@
+from sigaa.parsers.curriculo import parse_components, prerequisite_met
+
+DATA = {
+    "disciplinas": [
+        {"codigo": "AAA0001", "nome": "INTRO", "tipoIntegralizacao": "OB", "periodo": 1,
+         "cargaHoraria": 60, "obrigatoria": True, "situacao": "CONCLUIDO"},
+        {"codigo": "BBB0002", "nome": "SEGUNDA", "tipoIntegralizacao": "OB", "periodo": 2,
+         "cargaHoraria": 60, "obrigatoria": True, "situacao": "PENDENTE",
+         "expressaoPreRequisito": "( AAA0001 ) "},
+        {"codigo": "CCC0003", "nome": "TERCEIRA", "tipoIntegralizacao": "OP", "periodo": 3,
+         "cargaHoraria": 30, "obrigatoria": False, "situacao": "PENDENTE",
+         "expressaoPreRequisito": "( BBB0002 ) E ( AAA0001 OU DDD0004 ) "},
+    ]
+}
+
+
+def test_parse_components_flags():
+    comps = {c.code: c for c in parse_components(DATA)}
+    assert comps["AAA0001"].completed and comps["AAA0001"].prerequisite_met
+    assert not comps["BBB0002"].completed and comps["BBB0002"].prerequisite_met
+    assert not comps["CCC0003"].prerequisite_met  # BBB0002 not yet completed
+    assert comps["CCC0003"].hours == 30 and not comps["CCC0003"].mandatory
+
+
+def test_prerequisite_expressions():
+    done = {"AAA0001", "BBB0002"}
+    assert prerequisite_met(None, done)
+    assert prerequisite_met("", done)
+    assert prerequisite_met("( AAA0001 ) E ( BBB0002 )", done)
+    assert prerequisite_met("( ZZZ0009 ) OU ( AAA0001 )", done)
+    assert not prerequisite_met("( ZZZ0009 ) E ( AAA0001 )", done)
+
+
+def test_prerequisite_rejects_garbage():
+    import pytest
+
+    with pytest.raises(ValueError):
+        prerequisite_met("( AAA0001 ) E import os", set())


### PR DESCRIPTION
Adds `sigaa curriculo [--pending] [--mandatory] [--json]` and the `sigaa_get_curriculo` MCP tool, backed by the `/sigaa/portal/discente/integralizacao/dados/` JSON endpoint.

Endpoint quirks handled (all discovered against the live system):
- replies JSON only to XHR-shaped requests (`Accept: application/json` + `X-Requested-With: XMLHttpRequest`), plain GET gets the HTML shell
- the JSON body is latin-1 encoded
- 302s to an HTML shell unless the integralização page was opened first in the same session

Prerequisite expressions like `( A ) E ( B OU C )` are evaluated against completed components; pending components with unmet prerequisites are reported as blocked (`BLOQUEADA` in the CLI). The evaluator validates the substituted expression before evaluating, rejecting anything but boolean tokens.

Verified live: `sigaa curriculo --pending --mandatory` lists the expected pending mandatory components. Unit tests cover parsing, prerequisite logic, and the garbage-rejection path.