### PR TITLE
feat: matrícula on-line flow (list, select, confirm)

### DIFF
--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -161,6 +161,12 @@ def _build_parser() -> argparse.ArgumentParser:
     p_ics.add_argument("--out", help="output file (default: stdout)")
     p_ics.set_defaults(func=_cmd_ics)
 
+    p_matr = sub.add_parser("matricula", help="matrícula on-line: list open sections, select, confirm (networked)")
+    p_matr.add_argument("--select", nargs="+", metavar="TURMA_ID", help="add these sections to the enrollment request")
+    p_matr.add_argument("--confirm", action="store_true", help="press CONFIRMAR MATRÍCULAS after selecting (submits the request)")
+    p_matr.add_argument("--json", action="store_true")
+    p_matr.set_defaults(func=_cmd_matricula)
+
     p_hist = sub.add_parser("historico", help="download the academic transcript PDF (networked)")
     p_hist.add_argument("--out", default="historico.pdf", help="output file (default: historico.pdf)")
     p_hist.add_argument("--force", action="store_true", help="overwrite an existing output file")
@@ -473,6 +479,46 @@ def _cmd_ics(args, settings: Settings) -> int:
         print(f"wrote {args.out}")
     else:
         print(ics, end="")
+    return 0
+
+
+def _cmd_matricula(args, settings: Settings) -> int:
+    from .parsers import matricula as matricula_parser
+
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        print("missing credentials (set SIGAA_USER and keyring/SIGAA_PASS)", file=sys.stderr)
+        return 1
+    if args.confirm and not args.select:
+        print("--confirm requires --select", file=sys.stderr)
+        return 1
+    with SigaaClient(settings.username, password) as client:
+        curriculo_html = client.open_matricula_curriculo()
+        if not args.select:
+            turmas = client.list_open_turmas(curriculo_html)
+            if args.json:
+                print(json.dumps([vars(t) for t in turmas], ensure_ascii=False, indent=1))
+                return 0
+            for t in turmas:
+                flags = ("R" if t.has_reservation else "-") + ("A" if t.allowed else "-")
+                print(
+                    f"{t.turma_id} {flags} {t.level or '':3} {t.component_code:9} "
+                    f"{t.component_name[:40]:40} {t.kind[:10]:10} {t.turma_label or '':8} "
+                    f"{t.schedule_raw or '':10} {t.teachers or ''}"
+                )
+            print("\nflags: R = seats reserved for your course, A = matrícula permitida")
+            return 0
+        selecionadas = client.select_matricula_turmas(args.select, curriculo_html)
+        for message in matricula_parser.parse_messages(selecionadas):
+            print(message)
+        if not args.confirm:
+            print("selection staged only; re-run with --confirm to submit")
+            return 0
+        receipt = client.confirm_matricula(selecionadas)
+        for message in matricula_parser.parse_messages(receipt):
+            print(message)
+        number = matricula_parser.parse_request_number(receipt)
+        print(f"solicitação nº {number}" if number else "no request number found; verify in SIGAA")
     return 0
 
 

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -72,6 +72,67 @@ class SigaaClient:
         html = self._portal_menu_post("Minhas Notas")
         return grades_parser.parse_grades(html)
 
+    def open_matricula_curriculo(self) -> str:
+        """Navigate Portal -> Realizar Matrícula -> Iniciar Seleção; return the
+        'Turmas Abertas do Currículo' page HTML."""
+        intro = self._portal_menu_post("Realizar Matrícula")
+        return self._session.post(
+            config.MATRICULA_INSTRUCOES_URL,
+            {
+                "form": "form",
+                "form:btnIniciarSolicit": "x",
+                "javax.faces.ViewState": extract_viewstate(intro),
+            },
+        )
+
+    def list_open_turmas(self, curriculo_html: str | None = None):
+        """Open sections offered for the student's curriculum."""
+        from .parsers import matricula as matricula_parser
+
+        html = curriculo_html or self.open_matricula_curriculo()
+        return matricula_parser.parse_open_turmas(html)
+
+    def select_matricula_turmas(self, turma_ids: list[str], curriculo_html: str | None = None) -> str:
+        """Add sections to the enrollment request (not yet confirmed).
+
+        Returns the 'Turmas Selecionadas' page HTML; feedback messages on it
+        report which sections were accepted or rejected.
+        """
+        html = curriculo_html or self.open_matricula_curriculo()
+        form_match = re.search(
+            r'<form id="([^"]+)"[^>]*>(?:(?!</form>).)*?name="selecaoTurmas"', html, re.S
+        )
+        if not form_match:
+            raise ValueError("selection form not found on the matrícula page")
+        form = form_match.group(1)
+        return self._session.post(
+            config.MATRICULA_TURMAS_CURRICULO_URL,
+            {
+                form: form,
+                f"{form}:btaoSelecionarTurmas": f"{form}:btaoSelecionarTurmas",
+                "javax.faces.ViewState": extract_viewstate(html),
+                "selecaoTurmas": turma_ids,
+            },
+        )
+
+    def confirm_matricula(self, selecionadas_html: str) -> str:
+        """Press CONFIRMAR MATRÍCULAS on the 'Turmas Selecionadas' page.
+
+        Submits the enrollment request for processing. Returns the receipt
+        page HTML (contains the Solicitação de Matrícula number).
+        """
+        form = "formBotoesSuperiores"
+        return self._session.post(
+            config.MATRICULA_TURMAS_CURRICULO_URL.replace(
+                "turmas_curriculo.jsf", "turmas_selecionadas.jsf"
+            ),
+            {
+                form: form,
+                f"{form}:botaoSubmissao": f"{form}:botaoSubmissao",
+                "javax.faces.ViewState": extract_viewstate(selecionadas_html),
+            },
+        )
+
     def get_cra(self) -> Decimal:
         """Return the official CRA recorded in the academic transcript."""
         return transcript_parser.parse_cra_pdf(self.get_historico_pdf())

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -94,3 +94,7 @@ class Settings:
             except Exception:
                 pass
         return os.environ.get("SIGAA_PASS")
+
+# Matrícula on-line (enrollment request) flow.
+MATRICULA_INSTRUCOES_URL = f"{BASE}/graduacao/matricula/instrucoes.jsf"
+MATRICULA_TURMAS_CURRICULO_URL = f"{BASE}/graduacao/matricula/turmas_curriculo.jsf"

--- a/sigaa/http.py
+++ b/sigaa/http.py
@@ -59,7 +59,9 @@ class Session:
     def get(self, url: str) -> str:
         return self._request("GET", url)
 
-    def post(self, url: str, data: dict[str, str]) -> str:
+    def post(self, url: str, data: dict[str, str | list[str]]) -> str:
+        """POST form data. A list value repeats the key (httpx encodes it so;
+        tuples inside the mapping break h11)."""
         return self._request("POST", url, data=data)
 
     def post_bytes(self, url: str, data: dict[str, str]) -> bytes:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -688,6 +688,21 @@ def _read_html_document_resource(token: str) -> bytes:
 
 
 @mcp.tool()
+def sigaa_matricula_open_turmas() -> list[dict]:
+    """Open sections offered for enrollment (matrícula on-line). Networked, read-only.
+
+    Selection/confirmation is intentionally CLI-only ('sigaa matricula --select --confirm')
+    so an agent cannot submit an enrollment request on its own.
+    """
+    settings = Settings()
+    password = settings.resolve_password()
+    if not settings.username or not password:
+        return [{"error": "no credentials available"}]
+    with SigaaClient(settings.username, password) as client:
+        return [vars(t) for t in client.list_open_turmas()]
+
+
+@mcp.tool()
 def sigaa_sync(fetch_bodies: bool = False) -> dict:
     """Refresh the local store from SIGAA."""
     result = run_sync(Settings(), fetch_bodies=fetch_bodies)

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -314,3 +314,21 @@ class SipacProcessSearchPage:
     total_pages: int
     total_results: int
     results: list[SipacProcessSearchResult] = field(default_factory=list)
+
+
+@dataclass
+class OpenTurma:
+    """An open section offered for enrollment on the matrícula pages."""
+
+    turma_id: str  # value posted in the selecaoTurmas checkbox
+    component_code: str
+    component_name: str
+    kind: str  # e.g. "Optativa", "Obrig. Currículo"
+    level: str | None = None  # curriculum level label, e.g. "6º"
+    allowed: bool = True  # matrícula permitida icon on the component header
+    has_reservation: bool = False  # turma has seats reserved for the student's course
+    turma_label: str | None = None  # e.g. "Turma 01"
+    teachers: str | None = None
+    schedule_raw: str | None = None
+    room: str | None = None
+    capacity: str | None = None

--- a/sigaa/parsers/matricula.py
+++ b/sigaa/parsers/matricula.py
@@ -1,0 +1,89 @@
+"""Parse the matrícula on-line pages: open sections and submission receipts."""
+
+from __future__ import annotations
+
+import re
+
+from bs4 import BeautifulSoup
+
+from ..models import OpenTurma
+
+# Component codes are alphanumeric (e.g. DINF00049, 1107202), not digits-only.
+_COMPONENT_RE = re.compile(r"\*?\s*([A-Z0-9]{7,9}) - (.+?)\s*\(([^)]+)\)")
+_LEVEL_RE = re.compile(r"(\d+º) Nível")
+_SCHEDULE_RE = re.compile(r"\b[2-7]+[MTN][1-6]+\b")
+_REQUEST_NUMBER_RE = re.compile(r"Solicita[^\s]*o de Matr[^\s]*cula N[^\s]*\s*(\d+)")
+
+
+def parse_open_turmas(html: str) -> list[OpenTurma]:
+    """Open sections from the 'Turmas Abertas do Currículo' page."""
+    soup = BeautifulSoup(html, "lxml")
+    turmas: list[OpenTurma] = []
+    level: str | None = None
+    component: tuple[str, str, str, bool] | None = None
+    for row in soup.select("table tr"):
+        text = re.sub(r"\s+", " ", row.get_text(" ", strip=True))
+        level_match = _LEVEL_RE.match(text)
+        if level_match:
+            level = level_match.group(1)
+            continue
+        checkbox = row.find("input", {"name": "selecaoTurmas"})
+        component_match = _COMPONENT_RE.match(text)
+        if component_match and not checkbox:
+            allowed = row.find("img", src=re.compile("matricula_permitida")) is not None
+            component = (
+                component_match.group(1),
+                component_match.group(2),
+                component_match.group(3),
+                allowed,
+            )
+            continue
+        if checkbox and component:
+            cells = [re.sub(r"\s+", " ", td.get_text(" ", strip=True)) for td in row.find_all("td")]
+            cells = [c for c in cells if c and not c.startswith("Essa turma")]
+            schedule = next((c for c in cells if _SCHEDULE_RE.search(c)), None)
+            turma_label = next((c for c in cells if c.startswith("Turma")), None)
+            capacity = next((c for c in cells if c.endswith("alunos")), None)
+            label_idx = cells.index(turma_label) if turma_label in cells else -1
+            teachers = cells[label_idx + 1] if 0 <= label_idx < len(cells) - 1 else None
+            turmas.append(
+                OpenTurma(
+                    turma_id=checkbox["value"],
+                    component_code=component[0],
+                    component_name=component[1],
+                    kind=component[2],
+                    level=level,
+                    allowed=component[3],
+                    # The reservation flag lives in the checkbox id suffix.
+                    has_reservation="temReservas" in (checkbox.get("id") or ""),
+                    turma_label=turma_label,
+                    teachers=teachers,
+                    schedule_raw=schedule,
+                    capacity=capacity,
+                )
+            )
+    return turmas
+
+
+def parse_messages(html: str) -> list[str]:
+    """User-facing feedback messages (accepted/rejected selections, receipts)."""
+    soup = BeautifulSoup(html, "lxml")
+    messages = []
+    for panel in soup.select("#painel-erros li, .info, .erros li, .aviso"):
+        text = re.sub(r"\s+", " ", panel.get_text(" ", strip=True))
+        if text:
+            messages.append(text)
+    if not messages:
+        flat = re.sub(r"\s+", " ", soup.get_text(" ", strip=True))
+        for marker in ("selecionadas com sucesso", "submetidas com sucesso", "não possui reserva"):
+            index = flat.find(marker)
+            if index != -1:
+                messages.append(flat[max(0, index - 120) : index + len(marker)])
+    return messages
+
+
+def parse_request_number(html: str) -> str | None:
+    """The Solicitação de Matrícula number from the confirmation page."""
+    flat = re.sub(r"\s+", " ", BeautifulSoup(html, "lxml").get_text(" ", strip=True))
+    match = _REQUEST_NUMBER_RE.search(flat)
+    return match.group(1) if match else None

--- a/tests/test_matricula.py
+++ b/tests/test_matricula.py
@@ -1,0 +1,37 @@
+from sigaa.parsers.matricula import parse_messages, parse_open_turmas, parse_request_number
+
+PAGE = """
+<table>
+<tr><td>1º Nível</td></tr>
+<tr><td><img src="/sigaa/img/graduacao/matriculas/matricula_permitida.png"/></td>
+    <td>* ABC1234 - COMPONENTE UM (Obrig. Currículo)</td></tr>
+<tr><td><input type="checkbox" name="selecaoTurmas" value="111" id="cc_1t_01s_1CHK'_temReservas'"/></td>
+    <td>Turma 01</td><td>FULANO DE TAL</td><td>24M23</td><td>SALA 1</td><td>60 alunos</td></tr>
+<tr><td><img src="/sigaa/img/graduacao/matriculas/matricula_negada.png"/></td>
+    <td>* DEF5678 - COMPONENTE DOIS (Optativa)</td></tr>
+<tr><td><input type="checkbox" name="selecaoTurmas" value="222" id="cc_2t_01s_1CHK"/></td>
+    <td>Turma 02</td><td>BELTRANA DA SILVA</td><td>35T45</td><td>SALA 2</td><td>40 alunos</td></tr>
+</table>
+"""
+
+
+def test_parse_open_turmas():
+    turmas = {t.turma_id: t for t in parse_open_turmas(PAGE)}
+    one, two = turmas["111"], turmas["222"]
+    assert one.component_code == "ABC1234" and one.kind == "Obrig. Currículo"
+    assert one.level == "1º" and one.allowed and one.has_reservation
+    assert one.turma_label == "Turma 01" and one.teachers == "FULANO DE TAL"
+    assert one.schedule_raw == "24M23" and one.capacity == "60 alunos"
+    assert two.component_code == "DEF5678" and not two.allowed and not two.has_reservation
+    assert two.schedule_raw == "35T45"
+
+
+def test_parse_request_number():
+    html = "<html><body>Solicitação de Matrícula N° 633511 Imprimir</body></html>"
+    assert parse_request_number(html) == "633511"
+    assert parse_request_number("<html><body>nada</body></html>") is None
+
+
+def test_parse_messages_fallback():
+    html = "<html><body>As seguintes turmas foram selecionadas com sucesso: X - Turma 01.</body></html>"
+    assert any("selecionadas com sucesso" in m for m in parse_messages(html))


### PR DESCRIPTION
Adds `sigaa matricula` (CLI) and `sigaa_matricula_open_turmas` (MCP, read-only).

Flow: Portal → *Realizar Matrícula* → `instrucoes.jsf` (`btnIniciarSolicit`) → `turmas_curriculo.jsf` (open sections of the student's curriculum).

CLI:
- `sigaa matricula` — list open sections with turma id, reservation/permitida flags, schedule, teachers
- `sigaa matricula --select ID...` — stage sections on the enrollment request (prints SIGAA's accept/reject feedback)
- `sigaa matricula --select ID... --confirm` — press CONFIRMAR MATRÍCULAS and print the Solicitação number

Parser notes learned from the live pages:
- component codes are alphanumeric (`DINF00049`, `1107202`), not digits-only
- the course-reservation flag lives in the checkbox id suffix (`temReservas`)
- permitida/negada icons sit on the component header row
- the selection form id is a generated JSF id, resolved per page instead of hardcoded

Submission posts repeated `selecaoTurmas` keys (list value in the form mapping — tuples break h11) and then `formBotoesSuperiores:botaoSubmissao` on `turmas_selecionadas.jsf`.

Safety: selection/confirmation is CLI-only and double-gated (`--confirm` requires `--select`); the MCP surface stays read-only so an agent cannot submit an enrollment request on its own.

Verified live during the 2026.2 re-matrícula window (list, select incl. a rejected no-reservation section, confirm with receipt number). The window has since closed, so the listing now correctly returns empty with SIGAA's "página não está mais ativa" notice. Unit tests cover the parser paths.