### PR TITLE
feat: evaluate prerequisite expressions in curriculum status

### DIFF
--- a/sigaa/curriculum.py
+++ b/sigaa/curriculum.py
@@ -131,6 +131,7 @@ def _component_to_dict(
         "period_raw": component.period_raw,
         "workload_hours": component.workload_hours,
         "integration_type": component.integration_type,
+        "prerequisite_met": component.prerequisite_met,
     }
     if include_requirements:
         data["prerequisite"] = component.prerequisite

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -88,6 +88,8 @@ class CurriculumComponent:
     prerequisite: str | None = None
     corequisite: str | None = None
     period_raw: int | float | str | None = None
+    # Whether the prerequisite expression is satisfied by completed components.
+    prerequisite_met: bool = True
 
 
 @dataclass

--- a/sigaa/parsers/curriculum.py
+++ b/sigaa/parsers/curriculum.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from typing import Any
 
 from ..models import CurriculumComponent, CurriculumStatus, WorkloadProgress
@@ -40,6 +41,11 @@ def parse_curriculum(data: object) -> CurriculumStatus:
         _parse_component(item, index)
         for index, item in enumerate(components_data)
     ]
+    completed_codes = {c.code for c in components if c.status == "completed"}
+    for component in components:
+        component.prerequisite_met = prerequisite_met(
+            component.prerequisite, completed_codes
+        )
 
     return CurriculumStatus(
         curriculum=_required_string(payload, "curriculo"),
@@ -223,3 +229,27 @@ def _safe_raw_period(value: object) -> int | float | str | None:
     if isinstance(value, (int, float, str)):
         return value
     return None
+
+
+_COMPONENT_CODE_RE = re.compile(r"[A-Z0-9]{7,9}")
+_SAFE_BOOL_EXPR_RE = re.compile(r"^[\sTrueFalsandor()]+$")
+
+
+def prerequisite_met(expression: str | None, completed_codes: set[str]) -> bool:
+    """Evaluate a SIGAA prerequisite expression like ``( A ) E ( B OU C )``.
+
+    Component codes are substituted with True/False by membership in
+    ``completed_codes``; the substituted expression is validated to contain
+    only boolean tokens before evaluation.
+    """
+    if not expression or not expression.strip():
+        return True
+    expr = _COMPONENT_CODE_RE.sub(
+        lambda match: str(match.group(0) in completed_codes), expression
+    )
+    expr = expr.replace(" E ", " and ").replace(" OU ", " or ")
+    if not _SAFE_BOOL_EXPR_RE.match(expr):
+        raise CurriculumDataError(
+            f"unparseable prerequisite expression: {expression!r}"
+        )
+    return bool(eval(expr, {"__builtins__": {}}, {}))  # noqa: S307 - vetted tokens only

--- a/tests/test_curriculum_parser.py
+++ b/tests/test_curriculum_parser.py
@@ -95,3 +95,23 @@ def test_invalid_payload_raises_without_echoing_body(payload):
     assert "sessao expirada" not in message
     assert "<html>" not in message
     assert "login" not in message
+
+
+def test_prerequisite_met_evaluation():
+    from sigaa.parsers.curriculum import prerequisite_met
+
+    done = {"AAA0001", "BBB0002"}
+    assert prerequisite_met(None, done)
+    assert prerequisite_met("", done)
+    assert prerequisite_met("( AAA0001 ) E ( BBB0002 )", done)
+    assert prerequisite_met("( ZZZ0009 ) OU ( AAA0001 )", done)
+    assert not prerequisite_met("( ZZZ0009 ) E ( AAA0001 )", done)
+
+
+def test_prerequisite_met_rejects_garbage():
+    import pytest
+
+    from sigaa.parsers.curriculum import CurriculumDataError, prerequisite_met
+
+    with pytest.raises(CurriculumDataError):
+        prerequisite_met("( AAA0001 ) E import os", set())


### PR DESCRIPTION
Follow-up promised in #12 (closed as redundant with the shipped curriculum feature).

Adds `prerequisite_met` to `CurriculumComponent`, computed against completed components while parsing the integralização payload. SIGAA expressions like `( A ) E ( B OU C )` are substituted to boolean tokens by membership in the completed set and validated to contain only boolean tokens before evaluation — anything else raises `CurriculumDataError`.

Exposed through `curriculum_to_dict`, so `sigaa curriculum --json` and the `sigaa_get_curriculum` MCP tool now let consumers tell pending-but-takeable components apart from blocked ones.

Tests cover AND/OR combinations, empty/None expressions, and the garbage-rejection path. Full suite: 209 passed.