### PR TITLE
feat(mcp): SIGAA_MODE tool surface, and contain download paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > This is an unofficial personal project and is not affiliated with, endorsed
 > by, or supported by UFPB, SIGAA, or SIPAC. Use it responsibly, keep request rates low,
 > and follow the rules that apply to your SIGAA account.
+> See [Privacidade e segurança](docs/privacidade.mdx) for what is stored and what is never stored.
 
 Friendly CLI and MCP server for **SIGAA UFPB** and **SIPAC** public process lookup. Fetch your classes, grades, deadlines, and curriculum all at once without opening the web portal.
 
@@ -112,8 +113,12 @@ completed. `sigaa_get_cra` is also networked and reads the official CRA from the
 academic transcript; a new student may receive `source: "unavailable"` until
 SIGAA reports one. Neither response exposes SIGAA's internal student id.
 
-Document tools accept a safe filename (not an arbitrary path), never overwrite,
-and write under the app's private `downloads` directory. Set
+Every download tool accepts a safe filename (not an arbitrary path), never
+overwrites, and writes under the app's private `downloads` directory. This
+covers the three academic documents plus `sigaa_download_material` and
+`sigaa_download_tarefa_anexo`; on those two the parameter is named `filename`
+and no longer accepts a path. Filenames SIGAA supplies in `Content-Disposition`
+are sanitized rather than trusted. Set
 `SIGAA_DOWNLOAD_DIR` on the MCP server to choose another directory. A successful
 call returns both structured metadata (filename, MIME type, and size) and
 an opaque MCP `ResourceLink`. Clients that support resource links can present the
@@ -122,6 +127,38 @@ MCP without putting its bytes in the original tool response. The resource link i
 valid for the current server session, while the local file remains on disk. HTML
 certificates are exposed as download-only binary resources so an MCP client does
 not execute the report's active SIGAA markup inline.
+
+### Tool surface: `SIGAA_MODE`
+
+`SIGAA_MODE` picks which tools the MCP server exposes. It defaults to `local`,
+which exposes all 24 tools — **nothing is ever removed from a local or
+self-hosted install**.
+
+`SIGAA_MODE=hosted` is for a shared, multi-tenant deployment. It withholds the
+five tools that write files to the server's disk:
+
+| Withheld in hosted | Why |
+| --- | --- |
+| `sigaa_download_material` | Unbounded file writes; a class can hold hundreds of MB |
+| `sigaa_download_tarefa_anexo` | Same |
+| `sigaa_download_historico` | Needs a per-tenant download directory, which does not exist yet |
+| `sigaa_download_declaracao_vinculo` | Same |
+| `sigaa_download_atestado_matricula` | Same |
+
+Everything else stays, including `sigaa_sync` — without it a tenant's store is
+empty and every store-backed tool returns nothing. Its writes are confined to
+`SIGAA_DB`. No MCP tool mutates SIGAA state in any mode: enrollment
+selection and confirmation are deliberately CLI-only.
+
+The mode is applied at import, so it holds whether the server is started via
+`sigaa-mcp`, `python -m sigaa.mcp_server`, or by importing `mcp` from
+`sigaa.mcp_server` and mounting it. Withheld tools are removed from the tool
+manager, so they are uncallable rather than merely hidden. An unrecognized
+`SIGAA_MODE` raises at startup instead of falling back to `local`.
+
+A hosted deployment must also set `SIGAA_DB` and `SIGAA_DOWNLOAD_DIR` per
+tenant. Restoring the three academic-document tools in hosted mode depends on
+that isolation existing first.
 
 ## Scheduled polling
 

--- a/docs/privacidade.mdx
+++ b/docs/privacidade.mdx
@@ -1,0 +1,83 @@
+---
+title: "Privacidade e segurança"
+description: "O que este projeto faz com seus dados do SIGAA, o que ele nunca guarda, e como apagar tudo."
+---
+
+<Warning>
+  **Projeto não oficial.** Não tem vínculo com a UFPB, o SIGAA ou o SIPAC, e não é
+  endossado nem mantido por eles. É um projeto pessoal, de código aberto, feito por
+  um estudante. Ao usar, você concorda em seguir as regras que valem para a sua
+  própria conta do SIGAA.
+</Warning>
+
+Esta página vale para o **serviço hospedado** (o conector que você conecta ao Claude).
+Se você roda o projeto na sua própria máquina pelo CLI, nada sai do seu computador e
+nada aqui se aplica — suas credenciais ficam no chaveiro do seu sistema operacional.
+
+## O que é guardado
+
+- **Uma sessão do SIGAA** (o cookie que o SIGAA devolve depois do login), criptografada.
+  Ela expira sozinha em algumas horas, exatamente como acontece quando você fecha o
+  navegador.
+- **Uma cópia dos seus dados acadêmicos** que o serviço já leu: turmas, notícias das
+  turmas, materiais, prazos, notas e frequência. Serve para responder rápido e para
+  saber o que é novo desde a última verificação.
+
+## O que nunca é guardado
+
+- **Sua senha do SIGAA.** Ela é usada uma vez, no momento do login, para obter a sessão,
+  e não é gravada em lugar nenhum.
+- Nada é enviado para serviços de análise ou rastreamento. A página de conexão não tem
+  analytics de terceiros.
+- Cookies e credenciais nunca aparecem nos logs do servidor.
+
+Quando a sessão expirar, o serviço vai avisar e pedir que você conecte de novo. Isso é
+proposital: significa que o que está guardado tem prazo de validade curto.
+
+## O que o serviço pode fazer na sua conta
+
+Somente **leitura**. Nenhuma ferramenta disponível para a IA altera qualquer coisa no
+SIGAA — em nenhuma versão do projeto. Matrícula em turmas, por exemplo: a IA consegue
+listar as turmas abertas, mas selecionar e confirmar só é possível pela linha de comando,
+na sua própria máquina, feito por você. Uma sessão vazada pode expor informação; não pode
+mexer na sua vida acadêmica.
+
+A versão hospedada vai além e também não escreve arquivos: as ferramentas de download
+(histórico, atestado, materiais de aula) ficam desligadas no servidor compartilhado. Elas
+continuam existindo para quem roda o projeto na própria máquina.
+
+Isso não é uma promessa só de texto: o servidor hospedado roda com `SIGAA_MODE=hosted`,
+que remove essas ferramentas na inicialização, e existe um teste que tenta chamá-las
+mesmo assim e exige que a chamada falhe.
+
+## Apagar seus dados
+
+Tem um botão de apagar na página da sua conta. Ele remove a sessão e todos os dados
+acadêmicos guardados, na hora, sem precisar mandar e-mail para ninguém.
+
+## O que não dá para prometer
+
+Isso aqui é um projeto de estudante rodando em um servidor pequeno. Não há auditoria de
+segurança, certificação, nem garantia de disponibilidade. A criptografia dos dados
+protege contra vazamento de disco ou de backup — ela não protegeria contra alguém que
+comprometesse o servidor em execução, porque o próprio serviço precisa conseguir
+descriptografar para funcionar.
+
+Se isso te incomoda, e é razoável que incomode: o código é aberto, você pode ler
+exatamente o que acontece com o seu login, e pode rodar tudo na sua própria máquina.
+
+## Rodar por conta própria
+
+O CLI faz o mesmo trabalho localmente, sem servidor nenhum:
+
+```bash
+pipx install "sigaa-ai-agent[mcp]"
+sigaa init
+```
+
+Veja [Começando](/getting-started).
+
+## Contato
+
+Problemas, dúvidas ou pedido de remoção de dados:
+[github.com/PucaVaz/sigaa-for-ai-agents/issues](https://github.com/PucaVaz/sigaa-for-ai-agents/issues)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,9 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+# Pinned explicitly rather than inherited. ruff's default selection widened in
+# 0.16, which turned a green CI red on an unchanged tree; this is the set the
+# codebase was actually written against.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -36,6 +36,12 @@ LOGIN_REDIRECT_MARKER = "logon.jsf"
 KEYRING_SERVICE = "sigaa-ufpb"
 KEYRING_ACTIVE_USERNAME = "__active_username__"
 
+# MCP tool surfaces. Local keeps every tool; hosted is the reduced surface for a
+# shared deployment. Nothing is ever removed from the local/self-hosted build.
+LOCAL_MODE = "local"
+HOSTED_MODE = "hosted"
+SERVER_MODES = (LOCAL_MODE, HOSTED_MODE)
+
 # UFPB class-time slots. Day digits: 2=Mon .. 7=Sat. Shift: M/T/N.
 # NOTE: clock times below are an UNCONFIRMED default; confirm against a turma's
 # "Plano de Curso" before trusting them for calendar/ICS export.
@@ -61,6 +67,23 @@ def default_download_dir() -> Path:
     if override:
         return Path(override).expanduser()
     return default_db_path().parent / "downloads"
+
+
+def default_mode() -> str:
+    """Which tool surface the MCP server exposes (override via SIGAA_MODE).
+
+    ``local`` is the default and exposes everything. ``hosted`` is for a shared,
+    multi-tenant deployment and drops the tools that write to the server's disk.
+    An unrecognized value raises rather than falling back, so a typo cannot start
+    a hosted process with the full surface.
+    """
+    mode = os.environ.get("SIGAA_MODE", "").strip().lower()
+    if not mode:
+        return LOCAL_MODE
+    if mode not in SERVER_MODES:
+        valid = ", ".join(SERVER_MODES)
+        raise ValueError(f"SIGAA_MODE must be one of: {valid} (got {mode!r})")
+    return mode
 
 
 def default_username() -> str | None:

--- a/sigaa/documents.py
+++ b/sigaa/documents.py
@@ -121,6 +121,21 @@ def sanitize_download_filename(name: str) -> str:
     return normalized
 
 
+def write_private_file(
+    path: str | Path,
+    content: bytes,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Write bytes to a 0600 file, atomically when replacing an existing one."""
+    target = Path(path).expanduser()
+    if overwrite:
+        _atomic_replace(target, content)
+    else:
+        _exclusive_write(target, content)
+    return target.resolve()
+
+
 def write_academic_document(
     document: AcademicDocument,
     path: str | Path,
@@ -128,12 +143,7 @@ def write_academic_document(
     overwrite: bool = False,
 ) -> Path:
     """Write private document bytes, atomically when replacing an existing file."""
-    target = Path(path).expanduser()
-    if overwrite:
-        _atomic_replace(target, document.content)
-    else:
-        _exclusive_write(target, document.content)
-    return target.resolve()
+    return write_private_file(path, document.content, overwrite=overwrite)
 
 
 def _exclusive_write(target: Path, content: bytes) -> None:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -139,6 +139,20 @@ def sigaa_list_materials(class_code: str | None = None, kind: str | None = None)
     ]
 
 
+def _validate_requested_filename(requested: str) -> None:
+    """Reject anything that is not already one safe path component.
+
+    Called before the download runs, so an unsafe name fails fast instead of being
+    masked by a lookup or network error.
+    """
+    if (
+        not requested
+        or Path(requested).name != requested
+        or sanitize_download_filename(requested) != requested
+    ):
+        raise ToolError("filename must be one safe file name, not a path")
+
+
 def _write_downloaded_file(content: bytes, *, requested: str | None, server_name: str) -> Path:
     """Write downloaded bytes into the private download dir under a contained, safe name.
 
@@ -146,12 +160,7 @@ def _write_downloaded_file(content: bytes, *, requested: str | None, server_name
     comes from SIGAA's Content-Disposition, so it is sanitized rather than trusted.
     """
     if requested is not None:
-        if (
-            not requested
-            or Path(requested).name != requested
-            or sanitize_download_filename(requested) != requested
-        ):
-            raise ToolError("filename must be one safe file name, not a path")
+        _validate_requested_filename(requested)
         name = requested
     else:
         name = sanitize_download_filename(server_name)
@@ -170,6 +179,8 @@ def _write_downloaded_file(content: bytes, *, requested: str | None, server_name
 @mcp.tool()
 def sigaa_download_material(material_id: str, filename: str | None = None) -> str:
     """Download an uploaded class material (file) by its id. Networked. Returns the path written."""
+    if filename is not None:
+        _validate_requested_filename(filename)
     repo = _repo()
     material = next((m for m in repo.get_materials() if m.id == material_id), None)
     if material is None:
@@ -466,6 +477,8 @@ def sigaa_get_tarefa_body(deadline_id: str) -> dict:
 def sigaa_download_tarefa_anexo(deadline_id: str, filename: str | None = None) -> str:
     """Download a task's teacher attachment (Arquivo do Professor) by its deadline id.
     Networked. Returns the path written, or a message if the task has no attachment."""
+    if filename is not None:
+        _validate_requested_filename(filename)
     repo = _repo()
     item = next((d for d in repo.get_deadlines() if d.id == deadline_id), None)
     if item is None:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -31,6 +31,7 @@ from .documents import (
     document_spec,
     sanitize_download_filename,
     write_academic_document,
+    write_private_file,
 )
 from .exporters.ics import build_calendar
 from .http import AuthError
@@ -138,8 +139,36 @@ def sigaa_list_materials(class_code: str | None = None, kind: str | None = None)
     ]
 
 
+def _write_downloaded_file(content: bytes, *, requested: str | None, server_name: str) -> Path:
+    """Write downloaded bytes into the private download dir under a contained, safe name.
+
+    ``requested`` is caller-supplied and must already be one safe component. ``server_name``
+    comes from SIGAA's Content-Disposition, so it is sanitized rather than trusted.
+    """
+    if requested is not None:
+        if (
+            not requested
+            or Path(requested).name != requested
+            or sanitize_download_filename(requested) != requested
+        ):
+            raise ToolError("filename must be one safe file name, not a path")
+        name = requested
+    else:
+        name = sanitize_download_filename(server_name)
+
+    download_dir = default_download_dir().resolve()
+    target = download_dir / name
+    if target.exists() or target.is_symlink():
+        raise ToolError(f"download already exists: {name}")
+    download_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        return write_private_file(target, content)
+    except FileExistsError:
+        raise ToolError(f"download already exists: {name}") from None
+
+
 @mcp.tool()
-def sigaa_download_material(material_id: str, path: str | None = None) -> str:
+def sigaa_download_material(material_id: str, filename: str | None = None) -> str:
     """Download an uploaded class material (file) by its id. Networked. Returns the path written."""
     repo = _repo()
     material = next((m for m in repo.get_materials() if m.id == material_id), None)
@@ -156,11 +185,9 @@ def sigaa_download_material(material_id: str, path: str | None = None) -> str:
         turma = next((t for t in client.list_turmas() if t.id_turma == material.id_turma), None)
         if turma is None:
             return "could not locate the class for this material"
-        content, filename = client.download_material(turma, material_id)
-    out = path or filename
-    with open(out, "wb") as fh:
-        fh.write(content)
-    return f"wrote {out} ({len(content)} bytes)"
+        content, server_name = client.download_material(turma, material_id)
+    written = _write_downloaded_file(content, requested=filename, server_name=server_name)
+    return f"wrote {written} ({len(content)} bytes)"
 
 
 @mcp.tool()
@@ -436,7 +463,7 @@ def sigaa_get_tarefa_body(deadline_id: str) -> dict:
 
 
 @mcp.tool()
-def sigaa_download_tarefa_anexo(deadline_id: str, path: str | None = None) -> str:
+def sigaa_download_tarefa_anexo(deadline_id: str, filename: str | None = None) -> str:
     """Download a task's teacher attachment (Arquivo do Professor) by its deadline id.
     Networked. Returns the path written, or a message if the task has no attachment."""
     repo = _repo()
@@ -452,11 +479,9 @@ def sigaa_download_tarefa_anexo(deadline_id: str, path: str | None = None) -> st
         result = client.download_tarefa_attachment(deadline_id)
     if result is None:
         return "no teacher attachment on this task (or it is not a tarefa)"
-    content, filename = result
-    out = path or filename
-    with open(out, "wb") as fh:
-        fh.write(content)
-    return f"wrote {out} ({len(content)} bytes)"
+    content, server_name = result
+    written = _write_downloaded_file(content, requested=filename, server_name=server_name)
+    return f"wrote {written} ({len(content)} bytes)"
 
 
 @mcp.tool()

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -21,7 +21,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import CallToolResult, ResourceLink, TextContent
 
 from .client import SigaaClient
-from .config import Settings, default_download_dir
+from .config import HOSTED_MODE, Settings, default_download_dir, default_mode
 from .curriculum import curriculum_to_dict
 from .documents import (
     ATESTADO_MATRICULA,
@@ -51,6 +51,19 @@ from .store.db import connect
 from .store.repository import Repository
 
 mcp = FastMCP("sigaa-ufpb")
+
+# Tools hidden in hosted mode. All five write files to the server's disk, and a shared
+# deployment has no per-tenant download directory yet, so none of them belong there.
+# Nothing is hidden in local mode: a self-hosted install keeps the full surface.
+HOSTED_HIDDEN_TOOLS = frozenset(
+    {
+        "sigaa_download_material",
+        "sigaa_download_tarefa_anexo",
+        "sigaa_download_historico",
+        "sigaa_download_declaracao_vinculo",
+        "sigaa_download_atestado_matricula",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -761,6 +774,29 @@ def sigaa_sync(fetch_bodies: bool = False) -> dict:
             for d in result.new_deadlines
         ],
     }
+
+
+def hidden_tools_for_mode(mode: str) -> frozenset[str]:
+    """Tool names to withhold in the given mode. Pure; the deny list lives here."""
+    return HOSTED_HIDDEN_TOOLS if mode == HOSTED_MODE else frozenset()
+
+
+def apply_mode(server: FastMCP, mode: str) -> None:
+    """Remove the tools the mode withholds.
+
+    remove_tool deletes from the tool manager, so a withheld tool is uncallable and not
+    merely hidden from tools/list. It raises on an unknown name, which keeps the deny
+    list from going stale after a rename.
+
+    The sigaa-document:// resource handlers stay registered in every mode. When their
+    minting tools are gone the token table stays empty and every read fails closed,
+    and FastMCP offers no remove_resource to unregister them with.
+    """
+    for name in sorted(hidden_tools_for_mode(mode)):
+        server.remove_tool(name)
+
+
+apply_mode(mcp, default_mode())
 
 
 def main() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,26 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
 
-def mcp_subprocess_env(download_dir: Path, **extra: str) -> dict[str, str]:
-    """Env for spawning `python -m sigaa.mcp_server` with no ambient credentials.
 
-    Keyring is nulled and the download dir is redirected into the test's tmp_path so a
-    spawned server can never reach the developer's real account or files.
+@pytest.fixture
+def mcp_subprocess_env():
+    """Factory for the env used to spawn `python -m sigaa.mcp_server` in tests.
+
+    Strips ambient credentials, nulls the keyring backend and redirects the download
+    directory into the test's tmp_path, so a spawned server can never reach the
+    developer's real account or files. Extra variables are passed as keywords.
     """
-    environment = dict(os.environ)
-    environment.pop("SIGAA_USER", None)
-    environment.pop("SIGAA_PASS", None)
-    environment.pop("SIGAA_MODE", None)
-    environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-    environment["SIGAA_DOWNLOAD_DIR"] = str(download_dir)
-    environment.update(extra)
-    return environment
+
+    def build(download_dir: Path, **extra: str) -> dict[str, str]:
+        environment = dict(os.environ)
+        environment.pop("SIGAA_USER", None)
+        environment.pop("SIGAA_PASS", None)
+        environment.pop("SIGAA_MODE", None)
+        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+        environment["SIGAA_DOWNLOAD_DIR"] = str(download_dir)
+        environment.update(extra)
+        return environment
+
+    return build

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def mcp_subprocess_env(download_dir: Path, **extra: str) -> dict[str, str]:
+    """Env for spawning `python -m sigaa.mcp_server` with no ambient credentials.
+
+    Keyring is nulled and the download dir is redirected into the test's tmp_path so a
+    spawned server can never reach the developer's real account or files.
+    """
+    environment = dict(os.environ)
+    environment.pop("SIGAA_USER", None)
+    environment.pop("SIGAA_PASS", None)
+    environment.pop("SIGAA_MODE", None)
+    environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    environment["SIGAA_DOWNLOAD_DIR"] = str(download_dir)
+    environment.update(extra)
+    return environment

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from sigaa.config import HOSTED_MODE, LOCAL_MODE, default_mode
+
+
+def test_mode_defaults_to_local_when_unset(monkeypatch):
+    monkeypatch.delenv("SIGAA_MODE", raising=False)
+
+    assert default_mode() == LOCAL_MODE
+
+
+def test_mode_defaults_to_local_when_empty(monkeypatch):
+    monkeypatch.setenv("SIGAA_MODE", "   ")
+
+    assert default_mode() == LOCAL_MODE
+
+
+def test_mode_reads_hosted_ignoring_case_and_padding(monkeypatch):
+    monkeypatch.setenv("SIGAA_MODE", "  HOSTED ")
+
+    assert default_mode() == HOSTED_MODE
+
+
+def test_mode_rejects_an_unknown_value(monkeypatch):
+    monkeypatch.setenv("SIGAA_MODE", "hosted-v2")
+
+    with pytest.raises(ValueError, match="SIGAA_MODE must be one of"):
+        default_mode()

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from sigaa import mcp_server
+
+MATERIAL_ID = "mat-1"
+MATERIAL_BYTES = b"slides for week one"
+
+
+def _configure(monkeypatch, tmp_path, *, server_name: str):
+    """Point the material downloader at fake credentials, a fake client and tmp_path."""
+    material = SimpleNamespace(id=MATERIAL_ID, kind="file", id_turma="369279", url=None)
+    turma = SimpleNamespace(id_turma="369279")
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def list_turmas(self):
+            return [turma]
+
+        def download_material(self, requested_turma, material_id):
+            assert requested_turma is turma
+            assert material_id == MATERIAL_ID
+            return MATERIAL_BYTES, server_name
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    monkeypatch.setattr(mcp_server, "_repo", lambda: SimpleNamespace(get_materials=lambda: [material]))
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+
+
+def test_material_download_rejects_a_caller_supplied_path(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="slides.pdf")
+
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server.sigaa_download_material(MATERIAL_ID, "../escape.bin")
+
+    assert not (tmp_path.parent / "escape.bin").exists()
+
+
+def test_material_download_sanitizes_a_hostile_server_filename(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="../../evil.bin")
+
+    message = mcp_server.sigaa_download_material(MATERIAL_ID)
+
+    assert not (tmp_path.parent / "evil.bin").exists()
+    written = [item for item in tmp_path.iterdir() if item.is_file()]
+    assert len(written) == 1
+    assert written[0].parent == tmp_path
+    assert written[0].read_bytes() == MATERIAL_BYTES
+    assert str(written[0]) in message
+
+
+def test_material_download_refuses_to_clobber_an_existing_file(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="slides.pdf")
+
+    mcp_server.sigaa_download_material(MATERIAL_ID)
+
+    with pytest.raises(ToolError, match="already exists"):
+        mcp_server.sigaa_download_material(MATERIAL_ID)
+
+    assert (tmp_path / "slides.pdf").read_bytes() == MATERIAL_BYTES
+
+
+def test_material_download_writes_a_private_contained_file(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="slides.pdf")
+
+    message = mcp_server.sigaa_download_material(MATERIAL_ID, "aula-01.pdf")
+
+    target = tmp_path / "aula-01.pdf"
+    assert target.read_bytes() == MATERIAL_BYTES
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert str(target) in message
+    assert str(len(MATERIAL_BYTES)) in message

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -42,7 +42,8 @@ def _configure(monkeypatch, tmp_path, *, server_name: str):
     settings = SimpleNamespace(
         username="configured-user", resolve_password=lambda: "test-password"
     )
-    monkeypatch.setattr(mcp_server, "_repo", lambda: SimpleNamespace(get_materials=lambda: [material]))
+    repo = SimpleNamespace(get_materials=lambda: [material])
+    monkeypatch.setattr(mcp_server, "_repo", lambda: repo)
     monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
     monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
     monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -92,3 +92,93 @@ def test_material_download_writes_a_private_contained_file(monkeypatch, tmp_path
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert str(target) in message
     assert str(len(MATERIAL_BYTES)) in message
+
+
+DEADLINE_ID = "dl-1"
+ATTACHMENT_BYTES = b"assignment brief"
+
+
+def _configure_attachment(monkeypatch, tmp_path, *, server_name: str, result_present: bool = True):
+    """Point the attachment downloader at fake credentials, a fake client and tmp_path."""
+    deadline = SimpleNamespace(id=DEADLINE_ID, kind="tarefa", title="Tarefa 1")
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def download_tarefa_attachment(self, deadline_id):
+            assert deadline_id == DEADLINE_ID
+            if not result_present:
+                return None
+            return ATTACHMENT_BYTES, server_name
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    repo = SimpleNamespace(get_deadlines=lambda: [deadline])
+    monkeypatch.setattr(mcp_server, "_repo", lambda: repo)
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+
+
+def test_attachment_download_rejects_a_caller_supplied_path(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="brief.pdf")
+
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID, "../escape.bin")
+
+    assert not (tmp_path.parent / "escape.bin").exists()
+
+
+def test_attachment_download_sanitizes_a_hostile_server_filename(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="../../evil.bin")
+
+    message = mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID)
+
+    assert not (tmp_path.parent / "evil.bin").exists()
+    written = [item for item in tmp_path.iterdir() if item.is_file()]
+    assert len(written) == 1
+    assert written[0].read_bytes() == ATTACHMENT_BYTES
+    assert str(written[0]) in message
+
+
+def test_attachment_download_writes_a_private_contained_file(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="brief.pdf")
+
+    message = mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID, "tarefa-01.pdf")
+
+    target = tmp_path / "tarefa-01.pdf"
+    assert target.read_bytes() == ATTACHMENT_BYTES
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert str(target) in message
+
+
+def test_attachment_download_rejects_the_filename_before_touching_the_network(
+    monkeypatch, tmp_path
+):
+    """An unsafe name must fail even when the deadline lookup would have failed too."""
+
+    def explode():
+        raise AssertionError("must not reach the store with an unsafe filename")
+
+    monkeypatch.setattr(mcp_server, "_repo", lambda: explode())
+
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server.sigaa_download_tarefa_anexo("unknown", "../escape.bin")
+
+
+def test_attachment_download_reports_a_task_with_no_attachment(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="brief.pdf", result_present=False)
+
+    message = mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID)
+
+    assert "no teacher attachment" in message
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_mcp_mode.py
+++ b/tests/test_mcp_mode.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from sigaa import mcp_server
+from sigaa.config import HOSTED_MODE, LOCAL_MODE
+from tests.conftest import mcp_subprocess_env
+
+KEPT_IN_HOSTED = {"sigaa_sync", "sigaa_list_classes", "sigaa_matricula_open_turmas"}
+
+
+def _spawn(environment):
+    return StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "sigaa.mcp_server"],
+        env=environment,
+    )
+
+
+def test_local_mode_hides_nothing():
+    assert mcp_server.hidden_tools_for_mode(LOCAL_MODE) == frozenset()
+
+
+def test_hosted_mode_hides_the_disk_writers():
+    assert mcp_server.hidden_tools_for_mode(HOSTED_MODE) == mcp_server.HOSTED_HIDDEN_TOOLS
+
+
+def test_deny_list_only_names_tools_that_exist():
+    """A renamed tool must not leave a stale entry behind — remove_tool would raise."""
+    assert mcp_server.HOSTED_HIDDEN_TOOLS <= set(mcp_server.mcp._tool_manager._tools)
+
+
+def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path):
+    async def exercise_server():
+        environment = mcp_subprocess_env(tmp_path, SIGAA_MODE="hosted")
+
+        async with stdio_client(_spawn(environment)) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = {tool.name for tool in (await session.list_tools()).tools}
+
+                assert listed.isdisjoint(mcp_server.HOSTED_HIDDEN_TOOLS)
+                assert KEPT_IN_HOSTED <= listed
+
+                # Proves the tool is gone, not merely hidden: call_tool dispatches
+                # straight into the tool manager, bypassing any list_tools filter.
+                refused = await session.call_tool(
+                    "sigaa_download_material", {"material_id": "any"}
+                )
+                assert refused.isError is True
+                assert "Unknown tool" in " ".join(
+                    getattr(item, "text", "") for item in refused.content
+                )
+
+    asyncio.run(exercise_server())
+
+
+def test_default_server_still_exposes_every_tool(tmp_path):
+    """No behavior change for existing users: unset SIGAA_MODE keeps the full surface."""
+
+    async def exercise_server():
+        environment = mcp_subprocess_env(tmp_path)
+
+        async with stdio_client(_spawn(environment)) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = {tool.name for tool in (await session.list_tools()).tools}
+
+                assert mcp_server.HOSTED_HIDDEN_TOOLS <= listed
+
+    asyncio.run(exercise_server())

--- a/tests/test_mcp_mode.py
+++ b/tests/test_mcp_mode.py
@@ -12,7 +12,6 @@ from mcp.client.stdio import stdio_client
 
 from sigaa import mcp_server
 from sigaa.config import HOSTED_MODE, LOCAL_MODE
-from tests.conftest import mcp_subprocess_env
 
 KEPT_IN_HOSTED = {"sigaa_sync", "sigaa_list_classes", "sigaa_matricula_open_turmas"}
 
@@ -38,7 +37,7 @@ def test_deny_list_only_names_tools_that_exist():
     assert mcp_server.HOSTED_HIDDEN_TOOLS <= set(mcp_server.mcp._tool_manager._tools)
 
 
-def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path):
+def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path, mcp_subprocess_env):
     async def exercise_server():
         environment = mcp_subprocess_env(tmp_path, SIGAA_MODE="hosted")
 
@@ -63,7 +62,7 @@ def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path):
     asyncio.run(exercise_server())
 
 
-def test_default_server_still_exposes_every_tool(tmp_path):
+def test_default_server_still_exposes_every_tool(tmp_path, mcp_subprocess_env):
     """No behavior change for existing users: unset SIGAA_MODE keeps the full surface."""
 
     async def exercise_server():

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 
 import pytest
@@ -11,14 +10,12 @@ pytest.importorskip("mcp")
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+from tests.conftest import mcp_subprocess_env
+
 
 def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
     async def exercise_server():
-        environment = dict(os.environ)
-        environment.pop("SIGAA_USER", None)
-        environment.pop("SIGAA_PASS", None)
-        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-        environment["SIGAA_DOWNLOAD_DIR"] = str(tmp_path)
+        environment = mcp_subprocess_env(tmp_path)
         parameters = StdioServerParameters(
             command=sys.executable,
             args=["-m", "sigaa.mcp_server"],
@@ -53,3 +50,36 @@ def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
 
     asyncio.run(exercise_server())
     assert not (tmp_path.parent / "outside.pdf").exists()
+
+
+def test_mcp_stdio_rejects_a_path_in_the_material_download_filename(tmp_path):
+    async def exercise_server():
+        environment = mcp_subprocess_env(tmp_path)
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "sigaa.mcp_server"],
+            env=environment,
+        )
+
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                downloaders = {
+                    tool.name: tool
+                    for tool in listed.tools
+                    if tool.name in {"sigaa_download_material", "sigaa_download_tarefa_anexo"}
+                }
+                assert len(downloaders) == 2
+                for tool in downloaders.values():
+                    assert "filename" in tool.inputSchema.get("properties", {})
+                    assert "path" not in tool.inputSchema.get("properties", {})
+
+                rejected = await session.call_tool(
+                    "sigaa_download_material",
+                    {"material_id": "any", "filename": "../outside.bin"},
+                )
+                assert rejected.isError is True
+
+    asyncio.run(exercise_server())
+    assert not (tmp_path.parent / "outside.bin").exists()

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -10,10 +10,8 @@ pytest.importorskip("mcp")
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from tests.conftest import mcp_subprocess_env
 
-
-def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
+def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path, mcp_subprocess_env):
     async def exercise_server():
         environment = mcp_subprocess_env(tmp_path)
         parameters = StdioServerParameters(
@@ -52,7 +50,7 @@ def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
     assert not (tmp_path.parent / "outside.pdf").exists()
 
 
-def test_mcp_stdio_rejects_a_path_in_the_material_download_filename(tmp_path):
+def test_mcp_stdio_rejects_a_path_in_the_material_download_filename(tmp_path, mcp_subprocess_env):
     async def exercise_server():
         environment = mcp_subprocess_env(tmp_path)
         parameters = StdioServerParameters(


### PR DESCRIPTION
## Why

Groundwork for eventually running this as a hosted service that students connect to Claude, where one server process serves many people. That deployment needs a smaller tool surface than a student running the CLI on their own laptop — but the reduction has to be a **runtime mode, not a deletion**. Local and self-hosted installs keep every tool they have today, and the default is unchanged.

Along the way this fixes a live path-traversal bug that exists independently of any hosting plan.

## The security fix (ships regardless of the mode work)

`sigaa_download_material` and `sigaa_download_tarefa_anexo` wrote `path or filename` through a raw `open()`, resolved against the process CWD, with no sanitization, containment, or clobber check.

`filename` comes from SIGAA's `Content-Disposition`, so this was reachable **even when the caller passed no path** — a hostile or compromised response could write outside the intended directory and silently overwrite.

Both now route through `_write_downloaded_file`, mirroring the already-hardened academic-document path: caller-supplied names must be one safe component, server-supplied names are sanitized, targets resolve under `default_download_dir()`, and existing files and symlinks are refused.

Writing the tests surfaced a second, quieter bug: both tools looked the material or deadline up *before* validating the filename, so an unsafe name returned a friendly `"not found in store"` string rather than an error. Containment held, but the tool lied about why. Validation now runs first.

## `SIGAA_MODE`

| | Tools |
| --- | --- |
| `local` (default) | 24 — everything |
| `hosted` | 19 — no `sigaa_download_*` |

Hosted withholds the five tools that write files to the server's disk. Two are unbounded (a class can hold hundreds of MB); the three academic-document ones are already hardened but need a per-tenant download directory that does not exist yet.

Everything else stays, including `sigaa_sync` — without it a tenant's store is empty and every store-backed tool returns nothing, and its writes are confined to `SIGAA_DB`.

Two implementation choices worth reviewing:

- **Applied at import, not in `main()`.** A hosted deployment will mount the FastMCP object directly and never call `main()`; a flag parsed there would silently ship the full surface — the exact failure this feature exists to prevent.
- **`remove_tool`, not a `list_tools` override.** `call_tool` dispatches straight into the tool manager without consulting `list_tools`, so a hide-only implementation would leave withheld tools callable. There is a test that proves the difference.

An unrecognized `SIGAA_MODE` raises at startup rather than falling back to `local`, so a typo cannot boot a hosted process wide open.

## Tests

`223 → 228` passing. The load-bearing one spawns a real hosted stdio server and calls a withheld tool anyway, expecting `Unknown tool` — it fails for any hide-only implementation. A companion spawns with `SIGAA_MODE` unset and asserts the full surface is intact, covering "no behavior change for existing users."

Download coverage is symmetric across both tools: caller path rejected, hostile `Content-Disposition` sanitized, no clobber, private `0600` contained write, and rejection before the store is consulted. A drift guard asserts the deny list only names tools that exist, so a rename can't leave a stale entry behind.

New `tests/conftest.py` holds `mcp_subprocess_env`, replacing what was about to be a third copy of the env-sanitizing block used to spawn a credential-free server.

## Breaking change

`path` → `filename` on `sigaa_download_material` and `sigaa_download_tarefa_anexo`. A client passing `path=` now fails with an unexpected-argument error. Intended — the parameter no longer accepts a path — but it is a visible schema change and belongs in the release notes.

## Not in this PR

- `setup_wizard.py` is untouched. Local is the default; adding `SIGAA_MODE=local` to `merge_mcp_config`'s dict would flip `changed` to `True` for every existing user on their next `sigaa init` for no behavior gain.
- Material and attachment downloads still return a plain string rather than a `ResourceLink`. That needs `_register_document_resource` generalized past its hard-coded pdf/html branch.
- Per-tenant `SIGAA_DB` / `SIGAA_DOWNLOAD_DIR` isolation — the precondition for restoring the three document downloads in hosted mode.


## Also here: unbreaking CI

`main` was already red before this branch. ruff 0.16 (released 2026-08-27) widened its default rule selection, and the dev extra asks for `ruff>=0.6.0`, so CI picked it up silently — main's 08-28 run passed and its 08-31 run reported 49 errors on an unchanged tree (`I001`, `SIM117`, `BLE001`, `FURB167`, and others the codebase was never written against).

`[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]` restores exactly what was being enforced before and stops the next ruff release from doing this again. The ~50 flagged sites are deliberately left alone: adopting the wider rule set is a reasonable thing to want, but it is its own cleanup PR, not something a dependency bump should impose here.
