### PR TITLE
feat: scrape and store each class's teachers

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -179,6 +179,8 @@ Lista as turmas matriculadas.
 | Flag | Descrição |
 |---|---|
 | `--schedule` | decodifica os códigos de horário (ex.: `6M2345` → Sex, manhã) |
+| `--professors` | mostra os docentes de cada turma |
+| `--professor NOME` | só as turmas de um docente cujo nome contém o texto |
 | `--json` | saída em JSON |
 
 ### `news`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,9 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+# Pinned explicitly rather than inherited. ruff's default selection widened in
+# 0.16, which turned a green CI red on an unchanged tree; this is the set the
+# codebase was actually written against.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -79,6 +79,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_classes = sub.add_parser("classes", help="list classes from the store")
     p_classes.add_argument("--schedule", action="store_true", help="decode schedule codes")
+    p_classes.add_argument("--professors", action="store_true", help="show each class's teachers")
+    p_classes.add_argument(
+        "--professor", help="only classes taught by a teacher whose name contains this text"
+    )
     p_classes.add_argument("--json", action="store_true")
     p_classes.set_defaults(func=_cmd_classes)
 
@@ -270,12 +274,22 @@ def _cmd_sync(args, settings: Settings) -> int:
 
 def _cmd_classes(args, settings: Settings) -> int:
     repo = Repository(connect(settings.db_path))
-    turmas = repo.get_turmas()
+    stored = repo.get_turmas()
+    professors = _professors_by_turma(repo)
+    turmas = _filter_by_professor(stored, professors, args.professor) if args.professor else stored
+    show_professors = args.professors or bool(args.professor)
     if args.json:
-        print(json.dumps([_turma_json(t, args.schedule) for t in turmas], ensure_ascii=False, indent=2))
+        print(json.dumps(
+            [_turma_json(t, args.schedule, professors.get(t.id_turma, []) if show_professors else None)
+             for t in turmas],
+            ensure_ascii=False, indent=2,
+        ))
+        return 0
+    if not stored:
+        print("no classes in store — run `sigaa sync` first")
         return 0
     if not turmas:
-        print("no classes in store — run `sigaa sync` first")
+        print(f"no class taught by a teacher matching {args.professor!r}")
         return 0
     for t in turmas:
         line = f"{t.code or '?':12} {t.name}"
@@ -284,7 +298,25 @@ def _cmd_classes(args, settings: Settings) -> int:
         elif t.schedule_raw:
             line += f"  ({t.schedule_raw})"
         print(line)
+        if show_professors:
+            for prof in professors.get(t.id_turma, []):
+                print(f"             {prof.name}")
     return 0
+
+
+def _professors_by_turma(repo: Repository) -> dict[str, list]:
+    grouped: dict[str, list] = {}
+    for prof in repo.get_professors():
+        grouped.setdefault(prof.id_turma, []).append(prof)
+    return grouped
+
+
+def _filter_by_professor(turmas: list, professors: dict[str, list], query: str) -> list:
+    needle = query.casefold()
+    return [
+        t for t in turmas
+        if any(needle in p.name.casefold() for p in professors.get(t.id_turma, []))
+    ]
 
 
 def _cmd_news(args, settings: Settings) -> int:
@@ -870,8 +902,12 @@ def _sync_json(result) -> dict:
     }
 
 
-def _turma_json(t, with_schedule: bool) -> dict:
+def _turma_json(t, with_schedule: bool, professors: list | None = None) -> dict:
     data = {"code": t.code, "name": t.name, "room": t.room, "schedule_raw": t.schedule_raw}
+    if professors is not None:
+        data["professors"] = [
+            {"name": p.name, "email": p.email, "department": p.department} for p in professors
+        ]
     if with_schedule:
         data["schedule"] = [
             {"days": s.days, "shift": s.shift, "slots": s.slots}

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import sys
 import time
+import unicodedata
 from pathlib import Path
 
 import httpx
@@ -311,11 +312,17 @@ def _professors_by_turma(repo: Repository) -> dict[str, list]:
     return grouped
 
 
+def _fold_name(value: str) -> str:
+    """Casefold and strip accents so 'jose' matches 'José'."""
+    decomposed = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch)).casefold()
+
+
 def _filter_by_professor(turmas: list, professors: dict[str, list], query: str) -> list:
-    needle = query.casefold()
+    needle = _fold_name(query)
     return [
         t for t in turmas
-        if any(needle in p.name.casefold() for p in professors.get(t.id_turma, []))
+        if any(needle in _fold_name(p.name) for p in professors.get(t.id_turma, []))
     ]
 
 

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -27,6 +27,7 @@ from .models import (
     Grade,
     Material,
     NewsItem,
+    Professor,
     Student,
     Turma,
     TurmaGrade,
@@ -37,6 +38,7 @@ from .parsers import grades as grades_parser
 from .parsers import plano as plano_parser
 from .parsers import materials as materials_parser
 from .parsers import news as news_parser
+from .parsers import participantes as participantes_parser
 from .parsers import portal as portal_parser
 from .parsers import tarefa as tarefa_parser
 from .parsers import transcript as transcript_parser
@@ -263,6 +265,11 @@ class SigaaClient:
         """Plano de Curso: class schedule (cronograma) and evaluation dates."""
         html = self._turma_menu_post(turma, "Plano de Curso", turma_html)
         return plano_parser.parse_course_plan(html, turma.id_turma)
+
+    def list_professors(self, turma: Turma, turma_html: str | None = None) -> list[Professor]:
+        """Teaching staff of a turma (Participantes)."""
+        html = self._turma_menu_post(turma, "Participantes", turma_html)
+        return participantes_parser.parse_professors(html, turma.id_turma)
 
     def list_news(self, turma: Turma, turma_html: str | None = None) -> list[NewsItem]:
         html = turma_html or self.enter_turma(turma)

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -71,7 +71,11 @@ def _repo() -> Repository:
 
 @mcp.tool()
 def sigaa_list_classes() -> list[dict]:
-    """List enrolled classes from the local store."""
+    """List enrolled classes, with their teachers, from the local store."""
+    repo = _repo()
+    professors: dict[str, list[str]] = {}
+    for prof in repo.get_professors():
+        professors.setdefault(prof.id_turma, []).append(prof.name)
     return [
         {
             "code": t.code,
@@ -79,8 +83,23 @@ def sigaa_list_classes() -> list[dict]:
             "room": t.room,
             "schedule_raw": t.schedule_raw,
             "id_turma": t.id_turma,
+            "professors": professors.get(t.id_turma, []),
         }
-        for t in _repo().get_turmas()
+        for t in repo.get_turmas()
+    ]
+
+
+@mcp.tool()
+def sigaa_list_professors(class_code: str | None = None) -> list[dict]:
+    """List class teachers (name, e-mail, department) from the store, optionally for one class."""
+    repo = _repo()
+    id_turma = None
+    if class_code:
+        turma = repo.get_turma(class_code)
+        id_turma = turma.id_turma if turma else class_code
+    return [
+        {"class_id": p.id_turma, "name": p.name, "email": p.email, "department": p.department}
+        for p in repo.get_professors(id_turma=id_turma)
     ]
 
 

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -41,6 +41,20 @@ class Turma:
 
 
 @dataclass
+class Professor:
+    """A teacher of one turma, from the Turma Virtual 'Participantes' page.
+
+    Only the teaching staff is modelled; the enrolled students listed on the
+    same page are never parsed or stored.
+    """
+
+    id_turma: str
+    name: str
+    department: str | None = None
+    email: str | None = None
+
+
+@dataclass
 class NewsItem:
     """A class announcement. ``id`` is SIGAA's stable news id (dedup key)."""
 

--- a/sigaa/parsers/participantes.py
+++ b/sigaa/parsers/participantes.py
@@ -1,0 +1,88 @@
+"""Parse the Turma Virtual 'Participantes' page.
+
+Only the teaching staff is extracted. The page also lists every enrolled
+student (names and personal e-mail addresses); that block is deliberately
+never parsed or returned.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from bs4 import BeautifulSoup
+
+from ..models import Professor
+
+_PROFESSOR_LEGEND_RE = re.compile(r"professor(es)?\b")
+_DEPARTMENT_LABEL = "departamento"
+_EMAIL_LABEL = "e-mail"
+
+
+def parse_professors(html: str, id_turma: str) -> list[Professor]:
+    """Teaching staff listed under the 'Professores' fieldset of a turma."""
+    soup = BeautifulSoup(html, "lxml")
+    table = _professor_table(soup)
+    if table is None:
+        return []
+
+    professors: list[Professor] = []
+    for row in table.select("tr"):
+        name_el = row.select_one("strong")
+        name = name_el.get_text(" ", strip=True) if name_el else ""
+        if not name:
+            continue
+        fields = _labelled_fields(row)
+        professors.append(
+            Professor(
+                id_turma=id_turma,
+                name=name,
+                department=fields.get(_DEPARTMENT_LABEL),
+                email=fields.get(_EMAIL_LABEL),
+            )
+        )
+    return professors
+
+
+def _professor_table(soup: BeautifulSoup):
+    """The participantes table that follows the 'Professores (n)' legend.
+
+    SIGAA renders one table per role, each preceded by its own fieldset legend,
+    so the role is identified by the legend rather than by table position.
+    """
+    for legend in soup.select("fieldset legend"):
+        if not _PROFESSOR_LEGEND_RE.match(_normalized(legend.get_text(" ", strip=True))):
+            continue
+        table = legend.find_parent("fieldset").find_next("table", class_="participantes")
+        if table is not None:
+            return table
+    return None
+
+
+def _labelled_fields(row) -> dict[str, str]:
+    """Map each ``Label: <em>value</em>`` pair in the participant cell.
+
+    The label is a bare text node in front of the value's ``em``, so the pair is
+    recovered by walking back from each ``em`` rather than by line splitting.
+    """
+    fields: dict[str, str] = {}
+    for value_el in row.select("em"):
+        label = _preceding_label(value_el)
+        value = value_el.get_text(" ", strip=True)
+        if label and value:
+            fields.setdefault(label, value)
+    return fields
+
+
+def _preceding_label(value_el) -> str | None:
+    for node in value_el.previous_siblings:
+        text = _normalized(node.get_text(" ", strip=True) if hasattr(node, "get_text") else str(node))
+        if not text:
+            continue
+        return text.rstrip(":") if text.endswith(":") else None
+    return None
+
+
+def _normalized(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).replace("\xa0", " ")
+    return " ".join(normalized.split()).casefold()

--- a/sigaa/services/sync.py
+++ b/sigaa/services/sync.py
@@ -12,7 +12,16 @@ from dataclasses import dataclass, field
 
 from ..client import SigaaClient
 from ..config import Settings
-from ..models import Attendance, Deadline, Material, NewsItem, Student, Turma, TurmaGrade
+from ..models import (
+    Attendance,
+    Deadline,
+    Material,
+    NewsItem,
+    Professor,
+    Student,
+    Turma,
+    TurmaGrade,
+)
 from ..store.db import connect
 from ..store.repository import Repository
 
@@ -64,6 +73,7 @@ def sync(settings: Settings, fetch_bodies: bool = False) -> SyncResult:
                 result.attendance_updates.extend(
                     _sync_turma_attendance(client, repo, turma, turma_html)
                 )
+                _sync_turma_professors(client, repo, turma, turma_html)
 
             for deadline in client.list_deadlines():
                 if repo.upsert_deadline(deadline):
@@ -162,6 +172,19 @@ def _sync_turma_attendance(
     if attendance is None:
         return []
     return [attendance] if repo.upsert_attendance(attendance) else []
+
+
+def _sync_turma_professors(
+    client: SigaaClient, repo: Repository, turma: Turma, turma_html: str
+) -> list[Professor]:
+    """Best-effort: persist the turma's teaching staff (Participantes)."""
+    try:
+        professors = client.list_professors(turma, turma_html)
+    except Exception:  # noqa: BLE001 - per-turma participants page is optional
+        return []
+    if professors:
+        repo.replace_professors(turma.id_turma, professors)
+    return professors
 
 
 def _slug(text: str) -> str:

--- a/sigaa/store/db.py
+++ b/sigaa/store/db.py
@@ -25,6 +25,15 @@ CREATE TABLE IF NOT EXISTS turma (
     updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS professor (
+    id_turma   TEXT NOT NULL REFERENCES turma(id_turma),
+    name       TEXT NOT NULL,
+    department TEXT,
+    email      TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (id_turma, name)
+);
+
 CREATE TABLE IF NOT EXISTS news (
     id         TEXT PRIMARY KEY,
     id_turma   TEXT NOT NULL REFERENCES turma(id_turma),

--- a/sigaa/store/repository.py
+++ b/sigaa/store/repository.py
@@ -12,6 +12,7 @@ from ..models import (
     Grade,
     Material,
     NewsItem,
+    Professor,
     Student,
     Turma,
     TurmaGrade,
@@ -61,6 +62,24 @@ class Repository:
             (code_or_id, code_or_id),
         ).fetchone()
         return _turma(row) if row else None
+
+    # --- professors ------------------------------------------------------
+    def replace_professors(self, id_turma: str, professors: list[Professor]) -> None:
+        """Set a class's teaching staff, dropping anyone no longer listed."""
+        self._conn.execute("DELETE FROM professor WHERE id_turma = ?", (id_turma,))
+        self._conn.executemany(
+            """INSERT INTO professor (id_turma, name, department, email, updated_at)
+               VALUES (?, ?, ?, ?, datetime('now'))""",
+            [(p.id_turma, p.name, p.department, p.email) for p in professors],
+        )
+        self._conn.commit()
+
+    def get_professors(self, id_turma: str | None = None) -> list[Professor]:
+        where, params = ("WHERE id_turma = ?", [id_turma]) if id_turma else ("", [])
+        rows = self._conn.execute(
+            f"SELECT * FROM professor {where} ORDER BY id_turma, name", params
+        ).fetchall()
+        return [_professor(r) for r in rows]
 
     # --- news ------------------------------------------------------------
     def known_news_ids(self, id_turma: str) -> set[str]:
@@ -348,6 +367,13 @@ def _turma(row: sqlite3.Row) -> Turma:
     return Turma(
         id_turma=row["id_turma"], name=row["name"], code=row["code"], room=row["room"],
         schedule_raw=row["schedule_raw"], semester=row["semester"],
+    )
+
+
+def _professor(row: sqlite3.Row) -> Professor:
+    return Professor(
+        id_turma=row["id_turma"], name=row["name"], department=row["department"],
+        email=row["email"],
     )
 
 

--- a/tests/fixtures/participantes.html
+++ b/tests/fixtures/participantes.html
@@ -1,0 +1,54 @@
+<html>
+<body>
+<form id="j_id_jsp_1900130699_230" name="j_id_jsp_1900130699_230" method="post" action="/sigaa/ava/participantes.jsf">
+	<fieldset>
+		<legend> Professores (2)</legend></fieldset>
+		<table class="participantes">
+			<tr class="odd">
+				<td width="72" align="center">
+					<img src="/sigaa/verFoto?idFoto=1000001&amp;key=abc" width="60" height="75" />
+				</td>
+				<td valign="top">
+						<img src="/sigaa/img/portal_turma/offline.png" title="Usu&aacute;rio Off-Line no SIGAA" />
+						<strong>
+							<a href="http://www.ufpb.br/docente/exemplo" target="_blank" title="Acesse a p&#225;gina p&#250;blica deste docente" >CLARA DANTAS DE EXEMPLO</a>
+						</strong> <br/>
+						Departamento: <em>CI - DEPARTAMENTO DE INFORM&#193;TICA</em> <br/>
+						Forma&#231;&#227;o: <em>DOUTORADO</em> <br/>
+						E-Mail: <em>clara@ci.ufpb.br</em> <br/>
+						Breve resumo do curr&#237;culo do docente.
+				</td>
+			</tr>
+			<tr class="even">
+				<td width="72" align="center"></td>
+				<td valign="top">
+						<strong>SEGUNDO DOCENTE DE EXEMPLO</strong> <br/>
+						Departamento: <em>CI - DEPARTAMENTO DE SISTEMAS DE COMPUTA&#199;&#195;O</em> <br/>
+						Forma&#231;&#227;o: <em>MESTRADO</em> <br/>
+				</td>
+			</tr>
+		</table>
+		<br />
+		<fieldset>
+			<legend> Alunos (2)</legend>
+		</fieldset>
+			<input type="hidden" value="aluno.um@example.com, aluno.dois@example.com" id="emailsAlunos">
+			<table class="participantes">
+				<tr class="even">
+					<td width="47"></td>
+					<td valign="top">
+						<strong>ALUNO UM DE EXEMPLO</strong> <br/>
+						E-Mail: <em>aluno.um@example.com</em> <br/>
+					</td>
+				</tr>
+				<tr class="odd">
+					<td width="47"></td>
+					<td valign="top">
+						<strong>ALUNO DOIS DE EXEMPLO</strong> <br/>
+						E-Mail: <em>aluno.dois@example.com</em> <br/>
+					</td>
+				</tr>
+			</table>
+</form>
+</body>
+</html>

--- a/tests/test_participantes.py
+++ b/tests/test_participantes.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from sigaa.parsers import participantes as participantes_parser
+from sigaa.store.db import connect
+from sigaa.store.repository import Repository
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PARTICIPANTES = (FIXTURES / "participantes.html").read_text(encoding="utf-8")
+ID_TURMA = "379201"
+
+
+def test_parse_professors_reads_name_department_and_email():
+    professors = participantes_parser.parse_professors(PARTICIPANTES, ID_TURMA)
+
+    assert [p.name for p in professors] == [
+        "CLARA DANTAS DE EXEMPLO",
+        "SEGUNDO DOCENTE DE EXEMPLO",
+    ]
+    assert all(p.id_turma == ID_TURMA for p in professors)
+
+    first = professors[0]
+    assert first.department == "CI - DEPARTAMENTO DE INFORMÁTICA"
+    assert first.email == "clara@ci.ufpb.br"
+
+    # A teacher without a listed e-mail keeps the field empty rather than
+    # borrowing the next labelled value.
+    assert professors[1].email is None
+
+
+def test_parse_professors_ignores_the_student_roster():
+    professors = participantes_parser.parse_professors(PARTICIPANTES, ID_TURMA)
+
+    names = {p.name for p in professors}
+    emails = {p.email for p in professors}
+    assert "ALUNO UM DE EXEMPLO" not in names
+    assert "aluno.um@example.com" not in emails
+
+
+def test_parse_professors_without_the_fieldset_returns_empty():
+    assert participantes_parser.parse_professors("<html></html>", ID_TURMA) == []
+
+
+def test_replace_professors_is_idempotent_and_drops_removed_staff(tmp_path):
+    conn = connect(tmp_path / "sigaa.db")
+    repo = Repository(conn)
+    conn.execute("INSERT INTO turma (id_turma, code, name) VALUES (?, 'X', 'X')", (ID_TURMA,))
+
+    professors = participantes_parser.parse_professors(PARTICIPANTES, ID_TURMA)
+    repo.replace_professors(ID_TURMA, professors)
+    repo.replace_professors(ID_TURMA, professors)
+    assert len(repo.get_professors(ID_TURMA)) == 2
+
+    repo.replace_professors(ID_TURMA, professors[:1])
+    stored = repo.get_professors(ID_TURMA)
+    assert [p.name for p in stored] == ["CLARA DANTAS DE EXEMPLO"]
+    assert stored[0].email == "clara@ci.ufpb.br"
+    conn.close()

--- a/tests/test_participantes.py
+++ b/tests/test_participantes.py
@@ -55,3 +55,19 @@ def test_replace_professors_is_idempotent_and_drops_removed_staff(tmp_path):
     assert [p.name for p in stored] == ["CLARA DANTAS DE EXEMPLO"]
     assert stored[0].email == "clara@ci.ufpb.br"
     conn.close()
+
+
+def test_filter_by_professor_ignores_accents_and_case():
+    from types import SimpleNamespace
+
+    from sigaa.cli import _filter_by_professor
+
+    turmas = [SimpleNamespace(id_turma="1"), SimpleNamespace(id_turma="2")]
+    professors = {
+        "1": [SimpleNamespace(name="JOSÉ ANTÔNIO DA SILVA")],
+        "2": [SimpleNamespace(name="MARIA CLARA")],
+    }
+
+    assert [t.id_turma for t in _filter_by_professor(turmas, professors, "jose antonio")] == ["1"]
+    assert [t.id_turma for t in _filter_by_professor(turmas, professors, "Antônio")] == ["1"]
+    assert _filter_by_professor(turmas, professors, "nobody") == []


### PR DESCRIPTION
## Why

The store held no teacher for any class, so "who teaches Sistemas Distribuídos?" or "which classes does professor X teach?" could not be answered without opening the SIGAA portal by hand. No parser touched a page that names the teaching staff.

## What

The Turma Virtual **Participantes** page is the only place a student can see their teachers, so this adds a parser for it and threads the result through the store, the CLI and MCP.

- `sigaa/parsers/participantes.py` — parses the `Professores (n)` fieldset: name, departamento, e-mail. The role is identified by its `<legend>` rather than by table position, since SIGAA renders one table per role.
- `sigaa/models.py` — `Professor` dataclass.
- `sigaa/client.py` — `list_professors(turma)`, reusing the existing Turma Virtual menu postback.
- `sigaa/store/` — `professor` table keyed `(id_turma, name)`, with `replace_professors` / `get_professors`.
- `sigaa/services/sync.py` — best-effort per-turma fetch, matching the existing attendance/plano pattern: a class whose page fails must not abort the sync.
- CLI: `sigaa classes --professors`, plus `--professor NOME` to filter classes by teacher.
- MCP: `sigaa_list_classes` now returns `professors`; new read-only `sigaa_list_professors`.

## Privacy

The same page lists every enrolled student, with names and personal e-mail addresses. The parser reads the teaching-staff fieldset only — the student roster is never parsed, returned or stored — and a test asserts it.

## Testing

`tests/test_participantes.py` covers the parse (including a teacher with no listed e-mail), the roster exclusion, a page with no fieldset, and that `replace_professors` is idempotent and drops staff who are no longer listed. Full suite passes; verified live against 7 real classes.