### PR TITLE
feat: install via uv and generate portable MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "sigaa": {
-      "command": "/Users/pucavaz/Developer/puca/sigaa-ai-agent/.venv/bin/sigaa-mcp",
-      "env": {
-        "SIGAA_USER": "pucavaz"
-      }
+      "command": "uv",
+      "args": ["run", "--extra", "mcp", "sigaa-mcp"]
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,12 @@ sigaa init
 You can also use `SIGAA_USER`, `SIGAA_PASS`, and `SIGAA_DB`, but keep those
 values out of Git.
 
+The repository's committed `.mcp.json` runs the MCP server from your checkout
+via `uv run --extra mcp sigaa-mcp`, so agents you point at this repo exercise
+your local changes rather than a published build. Install
+[uv](https://docs.astral.sh/uv/) if you want that; the venv flow above works
+fine without it.
+
 ### First-Time Contributor?
 
 Welcome! If this is your first contribution, here's what to expect:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Friendly CLI and MCP server for **SIGAA UFPB** and **SIPAC** public process look
 
 ## Quickstart
 
-**Step 1:** Install `pipx` (once only):
+**Step 1:** Install [uv](https://docs.astral.sh/uv/) (once only):
 ```bash
-brew install pipx
-# or: python -m pip install --user pipx
+brew install uv
+# or: curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 **Step 2:** Install sigaa:
 ```bash
-pipx install "sigaa-tools[mcp]"
+uv tool install "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools"
 ```
 
 **Step 3:** Run the setup wizard:
@@ -149,12 +149,21 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
 {
   "mcpServers": {
     "sigaa": {
-      "command": "/abs/path/.venv/bin/sigaa-mcp",
-      "env": { "SIGAA_USER": "your_user" }
+      "command": "uvx",
+      "args": [
+        "--from",
+        "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools",
+        "sigaa-mcp"
+      ]
     }
   }
 }
 ```
+
+This form carries no machine-specific path, so the file stays valid when
+committed and shared with your team. `sigaa init` writes it for you. The server
+reads the active account from your keyring; add
+`"env": { "SIGAA_USER": "your_user" }` only if keyring is unavailable.
 
 ### Manual scheduled polling
 
@@ -170,7 +179,7 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
   <key>Label</key><string>ai.sigaa.sync</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/abs/path/.venv/bin/sigaa</string>
+    <string>/Users/you/.local/bin/sigaa</string>
     <string>sync</string>
   </array>
   <key>EnvironmentVariables</key>
@@ -179,7 +188,10 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
 </dict></plist>
 ```
 
-**Linux (cron)**: `*/30 * * * * SIGAA_USER=you /abs/.venv/bin/sigaa sync`
+`uv tool install` puts `sigaa` in `~/.local/bin`; launchd needs it spelled out in
+full, since it does not expand `~`. Run `which sigaa` to confirm yours.
+
+**Linux (cron)**: `*/30 * * * * SIGAA_USER=you $HOME/.local/bin/sigaa sync`
 (password from keyring, or add `SIGAA_PASS`).
 
 ## Architecture

--- a/sigaa/setup_wizard.py
+++ b/sigaa/setup_wizard.py
@@ -111,16 +111,39 @@ def resolve_script(name: str) -> str:
     return str(Path(sys.executable).resolve().parent / f"{name}{suffix}")
 
 
-def merge_mcp_config(path: Path, *, command: str, username: str) -> bool:
+# Source uvx resolves the server from. Switch to "sigaa-tools[mcp]" once the
+# package is published to PyPI; the generated config keeps working either way.
+MCP_PACKAGE_SPEC = "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools"
+
+
+def build_mcp_server(*, username: str | None = None) -> dict[str, object]:
+    """Return an MCP server entry, preferring a portable ``uvx`` invocation.
+
+    Pass ``username`` only when keyring cannot store the active account; the
+    server otherwise reads it back itself, keeping the config free of personal
+    data so it can be committed alongside the project.
+    """
+    if shutil.which("uv"):
+        server: dict[str, object] = {
+            "command": "uvx",
+            "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
+        }
+    else:
+        server = {"command": resolve_script("sigaa-mcp")}
+    if username:
+        server["env"] = {"SIGAA_USER": username}
+    return server
+
+
+def merge_mcp_config(path: Path, *, server: dict[str, object]) -> bool:
     path = path.expanduser()
     if path.exists():
         data = json.loads(path.read_text(encoding="utf-8"))
     else:
         data = {}
     servers = data.setdefault("mcpServers", {})
-    desired = {"command": command, "env": {"SIGAA_USER": username}}
-    changed = servers.get("sigaa") != desired
-    servers["sigaa"] = desired
+    changed = servers.get("sigaa") != server
+    servers["sigaa"] = server
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return changed
@@ -188,8 +211,10 @@ def run_init(settings: Settings, input_func: Callable[[str], str] = input) -> in
         default_mcp = Path.cwd() / ".mcp.json"
         answer = input_func(f"MCP config path [{default_mcp}]: ").strip()
         mcp_path = Path(answer).expanduser() if answer else default_mcp
-        command = resolve_script("sigaa-mcp")
-        merge_mcp_config(mcp_path, command=command, username=username)
+        # The active account comes back from keyring, so only pin it in the
+        # config when keyring could not store it.
+        server = build_mcp_server(username=None if login.password_stored else username)
+        merge_mcp_config(mcp_path, server=server)
         print(f"wrote MCP server config to {mcp_path}")
 
     if _confirm("Install scheduled sync? [y/N]: ", input_func):

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -6,8 +6,10 @@ from types import SimpleNamespace
 from sigaa import setup_wizard
 from sigaa.config import KEYRING_ACTIVE_USERNAME, KEYRING_SERVICE, Settings
 from sigaa.setup_wizard import (
+    MCP_PACKAGE_SPEC,
     build_cron_line,
     build_launchd_plist,
+    build_mcp_server,
     merge_mcp_config,
     resolve_script,
 )
@@ -57,6 +59,34 @@ def test_login_persists_username_for_the_next_process(monkeypatch):
     ]
 
 
+def test_build_mcp_server_prefers_uvx_when_uv_is_installed(monkeypatch):
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: "/opt/bin/uv")
+
+    assert build_mcp_server() == {
+        "command": "uvx",
+        "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
+    }
+
+
+def test_build_mcp_server_falls_back_to_console_script_without_uv(monkeypatch):
+    monkeypatch.setattr(
+        "sigaa.setup_wizard.shutil.which",
+        lambda name: None if name == "uv" else f"/opt/bin/{name}",
+    )
+
+    assert build_mcp_server() == {"command": "/opt/bin/sigaa-mcp"}
+
+
+def test_build_mcp_server_sets_username_only_when_keyring_cannot_hold_it(monkeypatch):
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: "/opt/bin/uv")
+
+    assert build_mcp_server(username="alice") == {
+        "command": "uvx",
+        "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
+        "env": {"SIGAA_USER": "alice"},
+    }
+
+
 def test_merge_mcp_config_preserves_existing_servers(tmp_path):
     path = tmp_path / ".mcp.json"
     path.write_text(
@@ -71,32 +101,80 @@ def test_merge_mcp_config_preserves_existing_servers(tmp_path):
         encoding="utf-8",
     )
 
-    changed = merge_mcp_config(path, command="/opt/bin/sigaa-mcp", username="alice")
+    changed = merge_mcp_config(path, server={"command": "uvx", "args": ["sigaa-mcp"]})
 
     assert changed is True
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["mcpServers"]["other"] == {"command": "/bin/other"}
-    assert data["mcpServers"]["sigaa"] == {
-        "command": "/opt/bin/sigaa-mcp",
-        "env": {"SIGAA_USER": "alice"},
-    }
+    assert data["mcpServers"]["sigaa"] == {"command": "uvx", "args": ["sigaa-mcp"]}
 
 
 def test_merge_mcp_config_creates_parent_and_file(tmp_path):
     path = tmp_path / "project" / ".mcp.json"
 
-    changed = merge_mcp_config(path, command="/opt/bin/sigaa-mcp", username="alice")
+    changed = merge_mcp_config(path, server={"command": "/opt/bin/sigaa-mcp"})
 
     assert changed is True
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert data == {
-        "mcpServers": {
-            "sigaa": {
-                "command": "/opt/bin/sigaa-mcp",
-                "env": {"SIGAA_USER": "alice"},
-            }
-        }
+    assert data == {"mcpServers": {"sigaa": {"command": "/opt/bin/sigaa-mcp"}}}
+
+
+def test_merge_mcp_config_reports_unchanged_when_server_already_matches(tmp_path):
+    path = tmp_path / ".mcp.json"
+    server = {"command": "uvx", "args": ["sigaa-mcp"]}
+    merge_mcp_config(path, server=server)
+
+    assert merge_mcp_config(path, server=server) is False
+
+
+def _run_init_writing_mcp(monkeypatch, tmp_path, *, password_stored: bool) -> dict:
+    """Drive run_init far enough to write .mcp.json, declining everything else."""
+    login = setup_wizard.LoginResult(
+        name="ALICE",
+        matricula="00000000000",
+        password_stored=password_stored,
+        storage_message="stored",
+        password="test-password",
+    )
+    monkeypatch.setattr(setup_wizard, "_prompt_login_until_ok", lambda *a, **k: login)
+    monkeypatch.setattr(
+        setup_wizard,
+        "sync",
+        lambda settings: SimpleNamespace(ok=True, turma_count=1, new_items=[], error=None),
+    )
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: "/opt/bin/uv")
+
+    mcp_path = tmp_path / ".mcp.json"
+    answers = ["1"]  # institution
+    if not password_stored:
+        answers.append("n")  # .env template, only offered when keyring failed
+    answers += [
+        "y",  # wire MCP
+        str(mcp_path),  # config path
+        "n",  # scheduled sync
+    ]
+    replies = iter(answers)
+    settings = Settings(db_path=tmp_path / "sigaa.db", username="alice")
+
+    assert setup_wizard.run_init(settings, lambda _prompt: next(replies)) == 0
+
+    return json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]["sigaa"]
+
+
+def test_run_init_writes_mcp_config_without_personal_data(monkeypatch, tmp_path):
+    server = _run_init_writing_mcp(monkeypatch, tmp_path, password_stored=True)
+
+    assert "env" not in server
+    assert server == {
+        "command": "uvx",
+        "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
     }
+
+
+def test_run_init_pins_username_when_keyring_is_unavailable(monkeypatch, tmp_path):
+    server = _run_init_writing_mcp(monkeypatch, tmp_path, password_stored=False)
+
+    assert server["env"] == {"SIGAA_USER": "alice"}
 
 
 def test_build_launchd_plist_uses_resolved_command_and_username():


### PR DESCRIPTION
Two problems, both in the install path.

**1. The documented install never worked.** `sigaa-tools` isn't on PyPI — `https://pypi.org/pypi/sigaa-tools/json` returns 404 and there's no `v*` tag, so `publish.yml` has never fired. That makes `pipx install "sigaa-tools[mcp]"` fail for every reader of the Quickstart.

**2. `sigaa init` generated a config that only worked on the machine that ran it.** It wrote `command: /abs/path/.venv/bin/sigaa-mcp` plus `SIGAA_USER` into `.mcp.json` — a file whose whole purpose is to be committed and shared. This repo's own `.mcp.json` had exactly that, pinned to `/Users/pucavaz/Developer/puca/sigaa-ai-agent/.venv/bin/sigaa-mcp`; it fails to start for anyone who clones.

## What this changes

Switches the documented installer to **uv**:

- `uv tool install "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools"` for the CLI, which puts `sigaa` and `sigaa-mcp` on `PATH` so every command in "Common commands" actually resolves.
- `uvx --from <spec> sigaa-mcp` for the generated MCP config — the same shape Anthropic's reference MCP servers (`mcp-server-git`, `mcp-server-fetch`) document, and the only form that stays valid once committed.

`SIGAA_USER` is dropped from the generated config: `config.default_username()` already reads the active account back from keyring, so the config needs no personal data. It's pinned only when keyring is unavailable, which the wizard already detects via `login.password_stored`.

`merge_mcp_config` was deciding both *what* config to write and *how* to merge it into the file. Split into `build_mcp_server` (prefers `uvx`, falls back to the resolved console script when `uv` isn't installed, so pipx and venv installs keep working) and `merge_mcp_config` (merge only).

This repo's `.mcp.json` now runs `uv run --extra mcp sigaa-mcp`, so an agent pointed at this checkout exercises local changes instead of a published build.

Install specs use `github.com/PucaVaz/sigaa-tools` rather than leaning on the redirect from the old `sigaa-for-ai-agents` name.

## Why uv rather than pip or brew

- Plain `pip install` is a step *backwards* from pipx: PEP 668 makes it fail with `externally-managed-environment` on Homebrew and Debian Pythons.
- A Homebrew formula would mean vendoring every dependency as a `resource` block and regenerating them on each bump — real recurring maintenance for little gain over `uv tool install`.
- `uvx` is what MCP clients expect for Python servers, and it's the only option that makes a committed `.mcp.json` portable.

## Verification

- 215 tests pass.
- 5 new tests, including the first coverage of `run_init` — two of them assert the generated config carries no personal data when keyring works, and pins the username when it doesn't.
- Ran for real, not just asserted: `uv tool install` (installs both executables to `~/.local/bin`), `uvx --from "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools" sigaa-mcp`, and `uv run --extra mcp sigaa-mcp` — both server forms start and correctly reject a malformed JSON-RPC line.

## Follow-up that needs you, @PucaVaz

Tag `v0.1.0` to fire the existing `publish.yml`. After that, `MCP_PACKAGE_SPEC` in `sigaa/setup_wizard.py` becomes `"sigaa-tools[mcp]"` and the install line shortens to `uv tool install "sigaa-tools[mcp]"` — one constant and one README line. I left the seam and a comment there for it. I can't do that part without release rights.

Also stale but untouched here: `[project.urls]` in `pyproject.toml` and a few README links still use the old `sigaa-for-ai-agents` name. Happy to fix separately if you want.

One call that's yours to make: how you'd rather handle the pre-release window. This ships the git spec so the Quickstart works today; the alternative is holding it until `v0.1.0` is out and shipping the PyPI form directly. Happy either way — say which and I'll adjust.
