### PR TITLE
fix(sync): stop plan deadlines churning on every sync

### DIFF
--- a/docs/sigaa-exploration.md
+++ b/docs/sigaa-exploration.md
@@ -32,7 +32,11 @@ positive: the literal "Selecione uma das turmas" string also appears in the
 Principal sidebar, so substring checks misread valid pages as bounced. Verified
 live: Tarefas, Plano de Curso, Frequência, and Participantes all render real
 content. Caveat: reuse one Principal page per postback — do not chain two deep
-posts off the same cached `turma_html` without re-entering.
+posts off the same cached `turma_html` without re-entering. Chaining silently
+returns the page of whatever turma the session currently sits on, which used to
+attribute one turma's Plano de Curso evaluations to another turma every sync.
+`SigaaClient._principal_for_postback` now enforces the rule: a cached Principal
+page is honoured once, and every later postback re-enters the turma first.
 
 ## Portal menu (`/sigaa/portais/discente/...`, sidebar postbacks)
 

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import replace
 from decimal import Decimal
@@ -54,6 +55,7 @@ class SigaaClient:
     ):
         self._session = Session(username, password, timeout=timeout)
         self._portal_html: str | None = None
+        self._spent_principals: set[str] = set()
 
     def _portal(self) -> str:
         if self._portal_html is None:
@@ -234,13 +236,31 @@ class SigaaClient:
         }
         return self._session.post(config.PORTAL_ACTION_URL, fields)
 
+    def _principal_for_postback(self, turma: Turma, turma_html: str | None) -> str:
+        """Return a Principal page that is safe to build one postback from.
+
+        A Turma Virtual postback consumes the server-side navigation state: the
+        session moves to the page that was opened, so a second postback built
+        from the same cached Principal page is answered with whatever turma the
+        session currently sits on -- silently returning another turma's content.
+        A cached page may therefore be used exactly once; every later postback
+        re-enters the turma first.
+        """
+        if turma_html:
+            digest = hashlib.sha256(turma_html.encode("utf-8", "replace")).hexdigest()
+            if digest not in self._spent_principals:
+                self._spent_principals.add(digest)
+                return turma_html
+        return self.enter_turma(turma)
+
     def _turma_menu_post(self, turma: Turma, link_text: str, turma_html: str | None = None) -> str:
         """Click a Turma Virtual (formMenu) menu item by its visible text.
 
         Pass ``turma_html`` (an already-fetched Principal page) to skip a redundant
-        ``enter_turma`` round-trip.
+        ``enter_turma`` round-trip -- honoured only for the first postback built
+        from that page, see :meth:`_principal_for_postback`.
         """
-        principal = turma_html or self.enter_turma(turma)
+        principal = self._principal_for_postback(turma, turma_html)
         field = portal_parser.find_menu_field(principal, link_text)
         if field is None:
             raise ValueError(f"turma menu item not found: {link_text!r}")
@@ -276,7 +296,7 @@ class SigaaClient:
         return news_parser.parse_news_list(html, turma.id_turma)
 
     def get_news_body(self, turma: Turma, news_id: str, turma_html: str | None = None) -> str | None:
-        html = turma_html or self.enter_turma(turma)
+        html = self._principal_for_postback(turma, turma_html)
         fields = news_parser.build_body_postback(
             html, news_id, extract_viewstate(html, default="j_id2")
         )

--- a/sigaa/services/sync.py
+++ b/sigaa/services/sync.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from collections import Counter
 from dataclasses import dataclass, field
 
 from ..client import SigaaClient
@@ -24,6 +25,8 @@ from ..models import (
 )
 from ..store.db import connect
 from ..store.repository import Repository
+
+UNTITLED_EVALUATION_SLUG = "avaliacao"
 
 
 @dataclass
@@ -146,11 +149,17 @@ def _sync_turma_plan(
         return []
     if plan is None:
         return []
+    if plan.id_turma != turma.id_turma:
+        return []  # a plan that cannot be attributed to this turma is never stored
     fresh: list[Deadline] = []
+    seen: Counter[str] = Counter()
     for ev in plan.evaluations:
+        slug = _slug(ev.description) or UNTITLED_EVALUATION_SLUG
+        occurrence = seen[slug]
+        seen[slug] += 1
         deadline = Deadline(
-            id=f"plan:{plan.id_turma}:{ev.date}:{_slug(ev.description)}",
-            id_turma=plan.id_turma,
+            id=_plan_deadline_id(turma.id_turma, slug, occurrence),
+            id_turma=turma.id_turma,
             kind="avaliacao",
             title=ev.description,
             date=ev.date,
@@ -159,6 +168,17 @@ def _sync_turma_plan(
         if repo.upsert_deadline(deadline):
             fresh.append(deadline)
     return fresh
+
+
+def _plan_deadline_id(id_turma: str, slug: str, occurrence: int) -> str:
+    """Identify a plan evaluation by turma and evaluation, never by its date.
+
+    Teachers reschedule evaluations, so a date in the id turns every move into a
+    brand-new deadline. ``occurrence`` disambiguates a plan that lists the same
+    evaluation description more than once.
+    """
+    suffix = f":{occurrence}" if occurrence else ""
+    return f"plan:{id_turma}:{slug}{suffix}"
 
 
 def _sync_turma_attendance(

--- a/sigaa/store/db.py
+++ b/sigaa/store/db.py
@@ -136,6 +136,17 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if not _has_column(conn, "deadline", "body"):
         conn.execute("ALTER TABLE deadline ADD COLUMN body TEXT")
         conn.commit()
+    _drop_legacy_plan_deadlines(conn)
+
+
+def _drop_legacy_plan_deadlines(conn: sqlite3.Connection) -> None:
+    """Remove plan deadlines keyed by date (``plan:<turma>:<dd/mm/yyyy>:<slug>``).
+
+    Those ids made a rescheduled evaluation look like a new deadline forever;
+    the current id is ``plan:<turma>:<slug>`` and is rebuilt on the next sync.
+    """
+    conn.execute("DELETE FROM deadline WHERE id GLOB 'plan:*:??/??/????:*'")
+    conn.commit()
 
 
 def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:

--- a/tests/test_plan_deadlines.py
+++ b/tests/test_plan_deadlines.py
@@ -1,5 +1,36 @@
-from sigaa.services.sync import _slug
-from sigaa.models import CoursePlan, PlanEvaluation
+from pathlib import Path
+
+from sigaa.models import CoursePlan, PlanEvaluation, Turma
+from sigaa.parsers.plano import parse_course_plan
+from sigaa.services.sync import _plan_deadline_id, _slug, _sync_turma_plan
+from sigaa.store.db import connect
+from sigaa.store.repository import Repository
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PLANO = (FIXTURES / "plano.html").read_text(encoding="utf-8")
+ID_TURMA = "369279"
+OTHER_ID_TURMA = "379107"
+
+
+class _StubClient:
+    """Returns a canned plan for every turma, like a bounced Turma Virtual would."""
+
+    def __init__(self, plan: CoursePlan | None):
+        self.plan = plan
+
+    def get_course_plan(self, turma: Turma, turma_html: str | None = None) -> CoursePlan | None:
+        return self.plan
+
+
+def _repo(tmp_path, *id_turmas: str) -> Repository:
+    repo = Repository(connect(tmp_path / "t.db"))
+    for id_turma in id_turmas or (ID_TURMA,):
+        repo.upsert_turma(Turma(id_turma=id_turma, name="SD", code="DSCO00022"))
+    return repo
+
+
+def _turma(id_turma: str = ID_TURMA) -> Turma:
+    return Turma(id_turma=id_turma, name="SD", code="DSCO00022")
 
 
 def test_slug_normalizes_accents_and_spaces():
@@ -7,11 +38,87 @@ def test_slug_normalizes_accents_and_spaces():
     assert _slug("Exame Final") == "exame-final"
 
 
-def test_plan_evaluation_deadline_ids_are_stable():
-    plan = CoursePlan(
-        id_turma="369279",
-        evaluations=[PlanEvaluation(date="11/06/2026", description="1ª avaliação")],
+def test_plan_deadline_ids_are_scoped_to_the_turma():
+    assert _plan_deadline_id(ID_TURMA, _slug("1ª avaliação"), 0) == "plan:369279:1a-avaliacao"
+    assert _plan_deadline_id(OTHER_ID_TURMA, _slug("1ª avaliação"), 0) != _plan_deadline_id(
+        ID_TURMA, _slug("1ª avaliação"), 0
     )
-    ev = plan.evaluations[0]
-    deadline_id = f"plan:{plan.id_turma}:{ev.date}:{_slug(ev.description)}"
-    assert deadline_id == "plan:369279:11/06/2026:1a-avaliacao"
+
+
+def test_plan_deadline_id_ignores_the_evaluation_date():
+    """A rescheduled evaluation keeps its identity instead of looking brand new."""
+    assert _plan_deadline_id(ID_TURMA, "exame-final", 0) == "plan:369279:exame-final"
+
+
+def test_repeated_evaluation_descriptions_get_distinct_ids():
+    first = _plan_deadline_id(ID_TURMA, "reposicao", 0)
+    second = _plan_deadline_id(ID_TURMA, "reposicao", 1)
+    assert first != second
+
+
+def test_syncing_the_same_plan_twice_yields_no_new_deadlines(tmp_path):
+    repo = _repo(tmp_path)
+    client = _StubClient(parse_course_plan(PLANO, ID_TURMA))
+    first = _sync_turma_plan(client, repo, _turma(), PLANO)
+    assert len(first) == 5
+    assert _sync_turma_plan(client, repo, _turma(), PLANO) == []
+
+
+def test_rescheduled_evaluation_updates_in_place(tmp_path):
+    repo = _repo(tmp_path)
+    plan = CoursePlan(
+        id_turma=ID_TURMA,
+        evaluations=[PlanEvaluation(date="17/12/2026", description="Exame Final")],
+    )
+    assert len(_sync_turma_plan(_StubClient(plan), repo, _turma(), PLANO)) == 1
+
+    moved = CoursePlan(
+        id_turma=ID_TURMA,
+        evaluations=[PlanEvaluation(date="21/12/2026", description="Exame Final")],
+    )
+    assert _sync_turma_plan(_StubClient(moved), repo, _turma(), PLANO) == []
+    stored = repo.get_deadlines(id_turma=ID_TURMA)
+    assert len(stored) == 1
+    assert stored[0].date == "21/12/2026"
+
+
+def test_plan_from_another_turma_is_refused(tmp_path):
+    """A page that cannot be attributed to this turma must not be persisted."""
+    repo = _repo(tmp_path, ID_TURMA, OTHER_ID_TURMA)
+    plan = CoursePlan(
+        id_turma=OTHER_ID_TURMA,
+        evaluations=[PlanEvaluation(date="17/12/2026", description="Exame Final")],
+    )
+    assert _sync_turma_plan(_StubClient(plan), repo, _turma(ID_TURMA), PLANO) == []
+    assert repo.get_deadlines() == []
+
+
+def test_plan_rows_do_not_leak_across_turmas(tmp_path):
+    repo = _repo(tmp_path, ID_TURMA, OTHER_ID_TURMA)
+    for id_turma in (ID_TURMA, OTHER_ID_TURMA):
+        plan = parse_course_plan(PLANO, id_turma)
+        _sync_turma_plan(_StubClient(plan), repo, _turma(id_turma), PLANO)
+
+    mine = repo.get_deadlines(id_turma=ID_TURMA)
+    theirs = repo.get_deadlines(id_turma=OTHER_ID_TURMA)
+    assert len(mine) == len(theirs) == 5
+    assert all(d.id.startswith(f"plan:{ID_TURMA}:") for d in mine)
+    assert all(d.id.startswith(f"plan:{OTHER_ID_TURMA}:") for d in theirs)
+
+
+def test_legacy_date_keyed_plan_deadlines_are_dropped_on_connect(tmp_path):
+    db = tmp_path / "t.db"
+    repo = _repo(tmp_path)
+    repo._conn.execute(
+        "INSERT INTO deadline (id, id_turma, kind, title, date) VALUES (?, ?, ?, ?, ?)",
+        (f"plan:{ID_TURMA}:17/12/2026:exame-final", ID_TURMA, "avaliacao", "Exame Final", "17/12/2026"),
+    )
+    repo._conn.execute(
+        "INSERT INTO deadline (id, id_turma, kind, title, date) VALUES (?, ?, ?, ?, ?)",
+        ("portal-event-1", ID_TURMA, "avaliacao", "Prova", "11/06/2026"),
+    )
+    repo._conn.commit()
+    repo._conn.close()
+
+    survivors = [d.id for d in Repository(connect(db)).get_deadlines()]
+    assert survivors == ["portal-event-1"]

--- a/tests/test_turma_postback_isolation.py
+++ b/tests/test_turma_postback_isolation.py
@@ -1,0 +1,88 @@
+"""A cached Principal page feeds exactly one Turma Virtual postback.
+
+Chaining a second postback off the same page leaves the session on the page the
+first postback opened, so SIGAA answers with whatever turma it currently sits on
+-- the mechanism behind plan rows landing on the wrong turma.
+"""
+
+from sigaa import config
+from sigaa.client import SigaaClient
+from sigaa.models import Turma
+
+TURMA = Turma(id_turma="369279", name="SD", form_id="form", field="form:turma")
+
+PORTAL = (
+    '<html><body><form id="j_id_jsp_1_1">'
+    '<input id="javax.faces.ViewState" name="javax.faces.ViewState" value="j_id1"/>'
+    "</form></body></html>"
+)
+
+
+def _principal(marker: str) -> str:
+    menu = "".join(
+        f"""<a href="#" onclick="jsfcljs(document.getElementById('formMenu'),"""
+        f"""{{'menu:{slug}':'menu:{slug}'}},'');">{label}</a>"""
+        for label, slug in (("Ver Notas", "notas"), ("Plano de Curso", "plano"))
+    )
+    return (
+        f'<html><body data-page="{marker}"><form id="formMenu">{menu}'
+        '<input id="javax.faces.ViewState" name="javax.faces.ViewState" value="j_id2"/>'
+        "</form></body></html>"
+    )
+
+
+class _FakeSession:
+    def __init__(self):
+        self.posts: list[tuple[str, dict]] = []
+        self.enters = 0
+
+    def post(self, url: str, fields: dict) -> str:
+        self.posts.append((url, fields))
+        if url == config.PORTAL_ACTION_URL:
+            self.enters += 1
+            return _principal(f"re-entered-{self.enters}")
+        return "<html><body>menu response</body></html>"
+
+
+def _client() -> tuple[SigaaClient, _FakeSession]:
+    client = SigaaClient.__new__(SigaaClient)
+    session = _FakeSession()
+    client._session = session
+    client._portal_html = PORTAL
+    client._spent_principals = set()
+    return client, session
+
+
+def test_first_postback_reuses_the_cached_principal_page():
+    client, session = _client()
+    client.get_turma_grades(TURMA, _principal("cached"))
+    assert session.enters == 0
+    assert session.posts[0][0] == config.AVA_URL
+
+
+def test_second_postback_re_enters_the_turma():
+    client, session = _client()
+    cached = _principal("cached")
+    client.get_turma_grades(TURMA, cached)
+    client.get_course_plan(TURMA, cached)
+
+    assert session.enters == 1
+    enter_url, enter_fields = session.posts[1]
+    assert enter_url == config.PORTAL_ACTION_URL
+    assert enter_fields["idTurma"] == TURMA.id_turma
+
+
+def test_news_body_after_a_menu_postback_re_enters_the_turma():
+    client, session = _client()
+    cached = _principal("cached")
+    client.get_course_plan(TURMA, cached)
+    client.get_news_body(TURMA, "1", cached)
+
+    assert session.enters == 1
+
+
+def test_a_freshly_entered_page_is_usable_for_one_postback():
+    client, session = _client()
+    fresh = client.enter_turma(TURMA)
+    client.get_course_plan(TURMA, fresh)
+    assert session.enters == 1  # only the explicit enter_turma


### PR DESCRIPTION
Ports #20 to `main`. #20 was merged into `master`, but `main` is the default branch and the one `uv tool install` resolves, so the fix never reached installs.

## Root cause
Entering a Turma Virtual page moves the server-side session onto that turma. `sync()` called `enter_turma` once and then chained up to four deep postbacks (news body, Ver Notas, Plano de Curso, Frequência) off the same cached Principal page, so from the second postback onward SIGAA answered with whichever turma the session had drifted to. Plano de Curso rows were therefore attributed to the wrong turma, and which one depended on how many postbacks had already run.

The deadline id embedded the evaluation date (`plan:<turma>:<date>:<slug>`), so each wrong or rescheduled date created a new primary key instead of updating the existing row.

## Impact
Repeated `sigaa sync` runs against unchanged SIGAA kept inserting new deadline rows indefinitely, and per-class Frequência (the last postback, the most drifted) reported absences for classes that had not met. Verified live: the store claimed 2 absences in five classes, while per-class live fetches showed absences in only two.

## Fix
- `sigaa/client.py`: `_principal_for_postback` honours a cached Principal page for exactly one postback and re-enters the turma for every later one.
- `sigaa/services/sync.py`: plan deadline id is `plan:<id_turma>:<slug>` plus an occurrence index; the date is mutable data. A plan whose `id_turma` does not match the turma being synced is refused.
- `sigaa/store/db.py`: legacy date-keyed plan rows are dropped on connect.
- `docs/sigaa-exploration.md`: documents the one-postback-per-Principal-page rule and where it is enforced.

## Tests
205 passed, 8 skipped. Adds `tests/test_plan_deadlines.py` and `tests/test_turma_postback_isolation.py`, both offline against HTML fixtures and temporary sqlite. Covers: syncing the same plan twice yields no new deadlines, rescheduled evaluations update in place, plan rows do not leak across turmas, and the second postback re-enters the turma.

## Cost
Syncs now make one extra `enter_turma` round-trip per deep postback after the first. That is the price of correct turma attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9LK1AmnzpFKHX997dcGH6