### PR TITLE
chore: restore main history and prepare 0.1.1 for PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ venv/
 .DS_Store
 .idea/
 .vscode/
+
+# Claude Code transcripts
+*-local-command-caveat*.txt
+2026-06-17-141152-local-command-caveatcaveat-the-messages-below.txt

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "sigaa": {
-      "command": "/Users/pucavaz/Developer/puca/sigaa-ai-agent/.venv/bin/sigaa-mcp",
-      "env": {
-        "SIGAA_USER": "pucavaz"
-      }
+      "command": "uv",
+      "args": ["run", "--extra", "mcp", "sigaa-mcp"]
     }
   }
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,12 @@ sigaa init
 You can also use `SIGAA_USER`, `SIGAA_PASS`, and `SIGAA_DB`, but keep those
 values out of Git.
 
+The repository's committed `.mcp.json` runs the MCP server from your checkout
+via `uv run --extra mcp sigaa-mcp`, so agents you point at this repo exercise
+your local changes rather than a published build. Install
+[uv](https://docs.astral.sh/uv/) if you want that; the venv flow above works
+fine without it.
+
 ### First-Time Contributor?
 
 Welcome! If this is your first contribution, here's what to expect:

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ Friendly CLI and MCP server for **SIGAA UFPB** and **SIPAC** public process look
 
 ## Quickstart
 
-**Step 1:** Install `pipx` (once only):
+**Step 1:** Install [uv](https://docs.astral.sh/uv/) (once only):
 ```bash
-brew install pipx
-# or: python -m pip install --user pipx
+brew install uv
+# or: curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
 **Step 2:** Install sigaa:
 ```bash
-pipx install "sigaa-tools[mcp]"
+uv tool install "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools"
 ```
 
 **Step 3:** Run the setup wizard:
@@ -149,12 +149,21 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
 {
   "mcpServers": {
     "sigaa": {
-      "command": "/abs/path/.venv/bin/sigaa-mcp",
-      "env": { "SIGAA_USER": "your_user" }
+      "command": "uvx",
+      "args": [
+        "--from",
+        "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools",
+        "sigaa-mcp"
+      ]
     }
   }
 }
 ```
+
+This form carries no machine-specific path, so the file stays valid when
+committed and shared with your team. `sigaa init` writes it for you. The server
+reads the active account from your keyring; add
+`"env": { "SIGAA_USER": "your_user" }` only if keyring is unavailable.
 
 ### Manual scheduled polling
 
@@ -170,7 +179,7 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
   <key>Label</key><string>ai.sigaa.sync</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/abs/path/.venv/bin/sigaa</string>
+    <string>/Users/you/.local/bin/sigaa</string>
     <string>sync</string>
   </array>
   <key>EnvironmentVariables</key>
@@ -179,7 +188,10 @@ Run with `sigaa-mcp` (stdio). Wire into Claude Code via `.mcp.json`:
 </dict></plist>
 ```
 
-**Linux (cron)**: `*/30 * * * * SIGAA_USER=you /abs/.venv/bin/sigaa sync`
+`uv tool install` puts `sigaa` in `~/.local/bin`; launchd needs it spelled out in
+full, since it does not expand `~`. Run `which sigaa` to confirm yours.
+
+**Linux (cron)**: `*/30 * * * * SIGAA_USER=you $HOME/.local/bin/sigaa sync`
 (password from keyring, or add `SIGAA_PASS`).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 > This is an unofficial personal project and is not affiliated with, endorsed
 > by, or supported by UFPB, SIGAA, or SIPAC. Use it responsibly, keep request rates low,
 > and follow the rules that apply to your SIGAA account.
+> See [Privacidade e segurança](docs/privacidade.mdx) for what is stored and what is never stored.
 
 Friendly CLI and MCP server for **SIGAA UFPB** and **SIPAC** public process lookup. Fetch your classes, grades, deadlines, and curriculum all at once without opening the web portal.
 
@@ -112,8 +113,12 @@ completed. `sigaa_get_cra` is also networked and reads the official CRA from the
 academic transcript; a new student may receive `source: "unavailable"` until
 SIGAA reports one. Neither response exposes SIGAA's internal student id.
 
-Document tools accept a safe filename (not an arbitrary path), never overwrite,
-and write under the app's private `downloads` directory. Set
+Every download tool accepts a safe filename (not an arbitrary path), never
+overwrites, and writes under the app's private `downloads` directory. This
+covers the three academic documents plus `sigaa_download_material` and
+`sigaa_download_tarefa_anexo`; on those two the parameter is named `filename`
+and no longer accepts a path. Filenames SIGAA supplies in `Content-Disposition`
+are sanitized rather than trusted. Set
 `SIGAA_DOWNLOAD_DIR` on the MCP server to choose another directory. A successful
 call returns both structured metadata (filename, MIME type, and size) and
 an opaque MCP `ResourceLink`. Clients that support resource links can present the
@@ -122,6 +127,38 @@ MCP without putting its bytes in the original tool response. The resource link i
 valid for the current server session, while the local file remains on disk. HTML
 certificates are exposed as download-only binary resources so an MCP client does
 not execute the report's active SIGAA markup inline.
+
+### Tool surface: `SIGAA_MODE`
+
+`SIGAA_MODE` picks which tools the MCP server exposes. It defaults to `local`,
+which exposes all 24 tools — **nothing is ever removed from a local or
+self-hosted install**.
+
+`SIGAA_MODE=hosted` is for a shared, multi-tenant deployment. It withholds the
+five tools that write files to the server's disk:
+
+| Withheld in hosted | Why |
+| --- | --- |
+| `sigaa_download_material` | Unbounded file writes; a class can hold hundreds of MB |
+| `sigaa_download_tarefa_anexo` | Same |
+| `sigaa_download_historico` | Needs a per-tenant download directory, which does not exist yet |
+| `sigaa_download_declaracao_vinculo` | Same |
+| `sigaa_download_atestado_matricula` | Same |
+
+Everything else stays, including `sigaa_sync` — without it a tenant's store is
+empty and every store-backed tool returns nothing. Its writes are confined to
+`SIGAA_DB`. No MCP tool mutates SIGAA state in any mode: enrollment
+selection and confirmation are deliberately CLI-only.
+
+The mode is applied at import, so it holds whether the server is started via
+`sigaa-mcp`, `python -m sigaa.mcp_server`, or by importing `mcp` from
+`sigaa.mcp_server` and mounting it. Withheld tools are removed from the tool
+manager, so they are uncallable rather than merely hidden. An unrecognized
+`SIGAA_MODE` raises at startup instead of falling back to `local`.
+
+A hosted deployment must also set `SIGAA_DB` and `SIGAA_DOWNLOAD_DIR` per
+tenant. Restoring the three academic-document tools in hosted mode depends on
+that isolation existing first.
 
 ## Scheduled polling
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -179,6 +179,8 @@ Lista as turmas matriculadas.
 | Flag | Descrição |
 |---|---|
 | `--schedule` | decodifica os códigos de horário (ex.: `6M2345` → Sex, manhã) |
+| `--professors` | mostra os docentes de cada turma |
+| `--professor NOME` | só as turmas de um docente cujo nome contém o texto |
 | `--json` | saída em JSON |
 
 ### `news`

--- a/docs/privacidade.mdx
+++ b/docs/privacidade.mdx
@@ -1,0 +1,83 @@
+---
+title: "Privacidade e segurança"
+description: "O que este projeto faz com seus dados do SIGAA, o que ele nunca guarda, e como apagar tudo."
+---
+
+<Warning>
+  **Projeto não oficial.** Não tem vínculo com a UFPB, o SIGAA ou o SIPAC, e não é
+  endossado nem mantido por eles. É um projeto pessoal, de código aberto, feito por
+  um estudante. Ao usar, você concorda em seguir as regras que valem para a sua
+  própria conta do SIGAA.
+</Warning>
+
+Esta página vale para o **serviço hospedado** (o conector que você conecta ao Claude).
+Se você roda o projeto na sua própria máquina pelo CLI, nada sai do seu computador e
+nada aqui se aplica — suas credenciais ficam no chaveiro do seu sistema operacional.
+
+## O que é guardado
+
+- **Uma sessão do SIGAA** (o cookie que o SIGAA devolve depois do login), criptografada.
+  Ela expira sozinha em algumas horas, exatamente como acontece quando você fecha o
+  navegador.
+- **Uma cópia dos seus dados acadêmicos** que o serviço já leu: turmas, notícias das
+  turmas, materiais, prazos, notas e frequência. Serve para responder rápido e para
+  saber o que é novo desde a última verificação.
+
+## O que nunca é guardado
+
+- **Sua senha do SIGAA.** Ela é usada uma vez, no momento do login, para obter a sessão,
+  e não é gravada em lugar nenhum.
+- Nada é enviado para serviços de análise ou rastreamento. A página de conexão não tem
+  analytics de terceiros.
+- Cookies e credenciais nunca aparecem nos logs do servidor.
+
+Quando a sessão expirar, o serviço vai avisar e pedir que você conecte de novo. Isso é
+proposital: significa que o que está guardado tem prazo de validade curto.
+
+## O que o serviço pode fazer na sua conta
+
+Somente **leitura**. Nenhuma ferramenta disponível para a IA altera qualquer coisa no
+SIGAA — em nenhuma versão do projeto. Matrícula em turmas, por exemplo: a IA consegue
+listar as turmas abertas, mas selecionar e confirmar só é possível pela linha de comando,
+na sua própria máquina, feito por você. Uma sessão vazada pode expor informação; não pode
+mexer na sua vida acadêmica.
+
+A versão hospedada vai além e também não escreve arquivos: as ferramentas de download
+(histórico, atestado, materiais de aula) ficam desligadas no servidor compartilhado. Elas
+continuam existindo para quem roda o projeto na própria máquina.
+
+Isso não é uma promessa só de texto: o servidor hospedado roda com `SIGAA_MODE=hosted`,
+que remove essas ferramentas na inicialização, e existe um teste que tenta chamá-las
+mesmo assim e exige que a chamada falhe.
+
+## Apagar seus dados
+
+Tem um botão de apagar na página da sua conta. Ele remove a sessão e todos os dados
+acadêmicos guardados, na hora, sem precisar mandar e-mail para ninguém.
+
+## O que não dá para prometer
+
+Isso aqui é um projeto de estudante rodando em um servidor pequeno. Não há auditoria de
+segurança, certificação, nem garantia de disponibilidade. A criptografia dos dados
+protege contra vazamento de disco ou de backup — ela não protegeria contra alguém que
+comprometesse o servidor em execução, porque o próprio serviço precisa conseguir
+descriptografar para funcionar.
+
+Se isso te incomoda, e é razoável que incomode: o código é aberto, você pode ler
+exatamente o que acontece com o seu login, e pode rodar tudo na sua própria máquina.
+
+## Rodar por conta própria
+
+O CLI faz o mesmo trabalho localmente, sem servidor nenhum:
+
+```bash
+pipx install "sigaa-ai-agent[mcp]"
+sigaa init
+```
+
+Veja [Começando](/getting-started).
+
+## Contato
+
+Problemas, dúvidas ou pedido de remoção de dados:
+[github.com/PucaVaz/sigaa-for-ai-agents/issues](https://github.com/PucaVaz/sigaa-for-ai-agents/issues)

--- a/docs/sigaa-exploration.md
+++ b/docs/sigaa-exploration.md
@@ -32,7 +32,11 @@ positive: the literal "Selecione uma das turmas" string also appears in the
 Principal sidebar, so substring checks misread valid pages as bounced. Verified
 live: Tarefas, Plano de Curso, Frequência, and Participantes all render real
 content. Caveat: reuse one Principal page per postback — do not chain two deep
-posts off the same cached `turma_html` without re-entering.
+posts off the same cached `turma_html` without re-entering. Chaining silently
+returns the page of whatever turma the session currently sits on, which used to
+attribute one turma's Plano de Curso evaluations to another turma every sync.
+`SigaaClient._principal_for_postback` now enforces the rule: a cached Principal
+page is honoured once, and every later postback re-enters the turma first.
 
 ## Portal menu (`/sigaa/portais/discente/...`, sidebar postbacks)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,9 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py311"
+
+# Pinned explicitly rather than inherited. ruff's default selection widened in
+# 0.16, which turned a green CI red on an unchanged tree; this is the set the
+# codebase was actually written against.
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/PucaVaz/sigaa-for-ai-agents"
-Repository = "https://github.com/PucaVaz/sigaa-for-ai-agents"
+Homepage = "https://github.com/PucaVaz/sigaa-tools"
+Repository = "https://github.com/PucaVaz/sigaa-tools"
+Issues = "https://github.com/PucaVaz/sigaa-tools/issues"
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.27,<2"]

--- a/sigaa/__init__.py
+++ b/sigaa/__init__.py
@@ -1,3 +1,3 @@
 """User-friendly SIGAA UFPB client (CLI + MCP) for automation workflows."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -79,6 +79,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_classes = sub.add_parser("classes", help="list classes from the store")
     p_classes.add_argument("--schedule", action="store_true", help="decode schedule codes")
+    p_classes.add_argument("--professors", action="store_true", help="show each class's teachers")
+    p_classes.add_argument(
+        "--professor", help="only classes taught by a teacher whose name contains this text"
+    )
     p_classes.add_argument("--json", action="store_true")
     p_classes.set_defaults(func=_cmd_classes)
 
@@ -270,12 +274,22 @@ def _cmd_sync(args, settings: Settings) -> int:
 
 def _cmd_classes(args, settings: Settings) -> int:
     repo = Repository(connect(settings.db_path))
-    turmas = repo.get_turmas()
+    stored = repo.get_turmas()
+    professors = _professors_by_turma(repo)
+    turmas = _filter_by_professor(stored, professors, args.professor) if args.professor else stored
+    show_professors = args.professors or bool(args.professor)
     if args.json:
-        print(json.dumps([_turma_json(t, args.schedule) for t in turmas], ensure_ascii=False, indent=2))
+        print(json.dumps(
+            [_turma_json(t, args.schedule, professors.get(t.id_turma, []) if show_professors else None)
+             for t in turmas],
+            ensure_ascii=False, indent=2,
+        ))
+        return 0
+    if not stored:
+        print("no classes in store — run `sigaa sync` first")
         return 0
     if not turmas:
-        print("no classes in store — run `sigaa sync` first")
+        print(f"no class taught by a teacher matching {args.professor!r}")
         return 0
     for t in turmas:
         line = f"{t.code or '?':12} {t.name}"
@@ -284,7 +298,25 @@ def _cmd_classes(args, settings: Settings) -> int:
         elif t.schedule_raw:
             line += f"  ({t.schedule_raw})"
         print(line)
+        if show_professors:
+            for prof in professors.get(t.id_turma, []):
+                print(f"             {prof.name}")
     return 0
+
+
+def _professors_by_turma(repo: Repository) -> dict[str, list]:
+    grouped: dict[str, list] = {}
+    for prof in repo.get_professors():
+        grouped.setdefault(prof.id_turma, []).append(prof)
+    return grouped
+
+
+def _filter_by_professor(turmas: list, professors: dict[str, list], query: str) -> list:
+    needle = query.casefold()
+    return [
+        t for t in turmas
+        if any(needle in p.name.casefold() for p in professors.get(t.id_turma, []))
+    ]
 
 
 def _cmd_news(args, settings: Settings) -> int:
@@ -870,8 +902,12 @@ def _sync_json(result) -> dict:
     }
 
 
-def _turma_json(t, with_schedule: bool) -> dict:
+def _turma_json(t, with_schedule: bool, professors: list | None = None) -> dict:
     data = {"code": t.code, "name": t.name, "room": t.room, "schedule_raw": t.schedule_raw}
+    if professors is not None:
+        data["professors"] = [
+            {"name": p.name, "email": p.email, "department": p.department} for p in professors
+        ]
     if with_schedule:
         data["schedule"] = [
             {"days": s.days, "shift": s.shift, "slots": s.slots}

--- a/sigaa/cli.py
+++ b/sigaa/cli.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import sys
 import time
+import unicodedata
 from pathlib import Path
 
 import httpx
@@ -311,11 +312,17 @@ def _professors_by_turma(repo: Repository) -> dict[str, list]:
     return grouped
 
 
+def _fold_name(value: str) -> str:
+    """Casefold and strip accents so 'jose' matches 'José'."""
+    decomposed = unicodedata.normalize("NFKD", value)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch)).casefold()
+
+
 def _filter_by_professor(turmas: list, professors: dict[str, list], query: str) -> list:
-    needle = query.casefold()
+    needle = _fold_name(query)
     return [
         t for t in turmas
-        if any(needle in p.name.casefold() for p in professors.get(t.id_turma, []))
+        if any(needle in _fold_name(p.name) for p in professors.get(t.id_turma, []))
     ]
 
 

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -27,6 +27,7 @@ from .models import (
     Grade,
     Material,
     NewsItem,
+    Professor,
     Student,
     Turma,
     TurmaGrade,
@@ -37,6 +38,7 @@ from .parsers import grades as grades_parser
 from .parsers import plano as plano_parser
 from .parsers import materials as materials_parser
 from .parsers import news as news_parser
+from .parsers import participantes as participantes_parser
 from .parsers import portal as portal_parser
 from .parsers import tarefa as tarefa_parser
 from .parsers import transcript as transcript_parser
@@ -263,6 +265,11 @@ class SigaaClient:
         """Plano de Curso: class schedule (cronograma) and evaluation dates."""
         html = self._turma_menu_post(turma, "Plano de Curso", turma_html)
         return plano_parser.parse_course_plan(html, turma.id_turma)
+
+    def list_professors(self, turma: Turma, turma_html: str | None = None) -> list[Professor]:
+        """Teaching staff of a turma (Participantes)."""
+        html = self._turma_menu_post(turma, "Participantes", turma_html)
+        return participantes_parser.parse_professors(html, turma.id_turma)
 
     def list_news(self, turma: Turma, turma_html: str | None = None) -> list[NewsItem]:
         html = turma_html or self.enter_turma(turma)

--- a/sigaa/client.py
+++ b/sigaa/client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import replace
 from decimal import Decimal
@@ -54,6 +55,7 @@ class SigaaClient:
     ):
         self._session = Session(username, password, timeout=timeout)
         self._portal_html: str | None = None
+        self._spent_principals: set[str] = set()
 
     def _portal(self) -> str:
         if self._portal_html is None:
@@ -234,13 +236,31 @@ class SigaaClient:
         }
         return self._session.post(config.PORTAL_ACTION_URL, fields)
 
+    def _principal_for_postback(self, turma: Turma, turma_html: str | None) -> str:
+        """Return a Principal page that is safe to build one postback from.
+
+        A Turma Virtual postback consumes the server-side navigation state: the
+        session moves to the page that was opened, so a second postback built
+        from the same cached Principal page is answered with whatever turma the
+        session currently sits on -- silently returning another turma's content.
+        A cached page may therefore be used exactly once; every later postback
+        re-enters the turma first.
+        """
+        if turma_html:
+            digest = hashlib.sha256(turma_html.encode("utf-8", "replace")).hexdigest()
+            if digest not in self._spent_principals:
+                self._spent_principals.add(digest)
+                return turma_html
+        return self.enter_turma(turma)
+
     def _turma_menu_post(self, turma: Turma, link_text: str, turma_html: str | None = None) -> str:
         """Click a Turma Virtual (formMenu) menu item by its visible text.
 
         Pass ``turma_html`` (an already-fetched Principal page) to skip a redundant
-        ``enter_turma`` round-trip.
+        ``enter_turma`` round-trip -- honoured only for the first postback built
+        from that page, see :meth:`_principal_for_postback`.
         """
-        principal = turma_html or self.enter_turma(turma)
+        principal = self._principal_for_postback(turma, turma_html)
         field = portal_parser.find_menu_field(principal, link_text)
         if field is None:
             raise ValueError(f"turma menu item not found: {link_text!r}")
@@ -276,7 +296,7 @@ class SigaaClient:
         return news_parser.parse_news_list(html, turma.id_turma)
 
     def get_news_body(self, turma: Turma, news_id: str, turma_html: str | None = None) -> str | None:
-        html = turma_html or self.enter_turma(turma)
+        html = self._principal_for_postback(turma, turma_html)
         fields = news_parser.build_body_postback(
             html, news_id, extract_viewstate(html, default="j_id2")
         )

--- a/sigaa/config.py
+++ b/sigaa/config.py
@@ -36,6 +36,12 @@ LOGIN_REDIRECT_MARKER = "logon.jsf"
 KEYRING_SERVICE = "sigaa-ufpb"
 KEYRING_ACTIVE_USERNAME = "__active_username__"
 
+# MCP tool surfaces. Local keeps every tool; hosted is the reduced surface for a
+# shared deployment. Nothing is ever removed from the local/self-hosted build.
+LOCAL_MODE = "local"
+HOSTED_MODE = "hosted"
+SERVER_MODES = (LOCAL_MODE, HOSTED_MODE)
+
 # UFPB class-time slots. Day digits: 2=Mon .. 7=Sat. Shift: M/T/N.
 # NOTE: clock times below are an UNCONFIRMED default; confirm against a turma's
 # "Plano de Curso" before trusting them for calendar/ICS export.
@@ -61,6 +67,23 @@ def default_download_dir() -> Path:
     if override:
         return Path(override).expanduser()
     return default_db_path().parent / "downloads"
+
+
+def default_mode() -> str:
+    """Which tool surface the MCP server exposes (override via SIGAA_MODE).
+
+    ``local`` is the default and exposes everything. ``hosted`` is for a shared,
+    multi-tenant deployment and drops the tools that write to the server's disk.
+    An unrecognized value raises rather than falling back, so a typo cannot start
+    a hosted process with the full surface.
+    """
+    mode = os.environ.get("SIGAA_MODE", "").strip().lower()
+    if not mode:
+        return LOCAL_MODE
+    if mode not in SERVER_MODES:
+        valid = ", ".join(SERVER_MODES)
+        raise ValueError(f"SIGAA_MODE must be one of: {valid} (got {mode!r})")
+    return mode
 
 
 def default_username() -> str | None:

--- a/sigaa/documents.py
+++ b/sigaa/documents.py
@@ -121,6 +121,21 @@ def sanitize_download_filename(name: str) -> str:
     return normalized
 
 
+def write_private_file(
+    path: str | Path,
+    content: bytes,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Write bytes to a 0600 file, atomically when replacing an existing one."""
+    target = Path(path).expanduser()
+    if overwrite:
+        _atomic_replace(target, content)
+    else:
+        _exclusive_write(target, content)
+    return target.resolve()
+
+
 def write_academic_document(
     document: AcademicDocument,
     path: str | Path,
@@ -128,12 +143,7 @@ def write_academic_document(
     overwrite: bool = False,
 ) -> Path:
     """Write private document bytes, atomically when replacing an existing file."""
-    target = Path(path).expanduser()
-    if overwrite:
-        _atomic_replace(target, document.content)
-    else:
-        _exclusive_write(target, document.content)
-    return target.resolve()
+    return write_private_file(path, document.content, overwrite=overwrite)
 
 
 def _exclusive_write(target: Path, content: bytes) -> None:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -139,6 +139,20 @@ def sigaa_list_materials(class_code: str | None = None, kind: str | None = None)
     ]
 
 
+def _validate_requested_filename(requested: str) -> None:
+    """Reject anything that is not already one safe path component.
+
+    Called before the download runs, so an unsafe name fails fast instead of being
+    masked by a lookup or network error.
+    """
+    if (
+        not requested
+        or Path(requested).name != requested
+        or sanitize_download_filename(requested) != requested
+    ):
+        raise ToolError("filename must be one safe file name, not a path")
+
+
 def _write_downloaded_file(content: bytes, *, requested: str | None, server_name: str) -> Path:
     """Write downloaded bytes into the private download dir under a contained, safe name.
 
@@ -146,12 +160,7 @@ def _write_downloaded_file(content: bytes, *, requested: str | None, server_name
     comes from SIGAA's Content-Disposition, so it is sanitized rather than trusted.
     """
     if requested is not None:
-        if (
-            not requested
-            or Path(requested).name != requested
-            or sanitize_download_filename(requested) != requested
-        ):
-            raise ToolError("filename must be one safe file name, not a path")
+        _validate_requested_filename(requested)
         name = requested
     else:
         name = sanitize_download_filename(server_name)
@@ -170,6 +179,8 @@ def _write_downloaded_file(content: bytes, *, requested: str | None, server_name
 @mcp.tool()
 def sigaa_download_material(material_id: str, filename: str | None = None) -> str:
     """Download an uploaded class material (file) by its id. Networked. Returns the path written."""
+    if filename is not None:
+        _validate_requested_filename(filename)
     repo = _repo()
     material = next((m for m in repo.get_materials() if m.id == material_id), None)
     if material is None:
@@ -466,6 +477,8 @@ def sigaa_get_tarefa_body(deadline_id: str) -> dict:
 def sigaa_download_tarefa_anexo(deadline_id: str, filename: str | None = None) -> str:
     """Download a task's teacher attachment (Arquivo do Professor) by its deadline id.
     Networked. Returns the path written, or a message if the task has no attachment."""
+    if filename is not None:
+        _validate_requested_filename(filename)
     repo = _repo()
     item = next((d for d in repo.get_deadlines() if d.id == deadline_id), None)
     if item is None:

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -71,7 +71,11 @@ def _repo() -> Repository:
 
 @mcp.tool()
 def sigaa_list_classes() -> list[dict]:
-    """List enrolled classes from the local store."""
+    """List enrolled classes, with their teachers, from the local store."""
+    repo = _repo()
+    professors: dict[str, list[str]] = {}
+    for prof in repo.get_professors():
+        professors.setdefault(prof.id_turma, []).append(prof.name)
     return [
         {
             "code": t.code,
@@ -79,8 +83,23 @@ def sigaa_list_classes() -> list[dict]:
             "room": t.room,
             "schedule_raw": t.schedule_raw,
             "id_turma": t.id_turma,
+            "professors": professors.get(t.id_turma, []),
         }
-        for t in _repo().get_turmas()
+        for t in repo.get_turmas()
+    ]
+
+
+@mcp.tool()
+def sigaa_list_professors(class_code: str | None = None) -> list[dict]:
+    """List class teachers (name, e-mail, department) from the store, optionally for one class."""
+    repo = _repo()
+    id_turma = None
+    if class_code:
+        turma = repo.get_turma(class_code)
+        id_turma = turma.id_turma if turma else class_code
+    return [
+        {"class_id": p.id_turma, "name": p.name, "email": p.email, "department": p.department}
+        for p in repo.get_professors(id_turma=id_turma)
     ]
 
 

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -31,6 +31,7 @@ from .documents import (
     document_spec,
     sanitize_download_filename,
     write_academic_document,
+    write_private_file,
 )
 from .exporters.ics import build_calendar
 from .http import AuthError
@@ -138,8 +139,36 @@ def sigaa_list_materials(class_code: str | None = None, kind: str | None = None)
     ]
 
 
+def _write_downloaded_file(content: bytes, *, requested: str | None, server_name: str) -> Path:
+    """Write downloaded bytes into the private download dir under a contained, safe name.
+
+    ``requested`` is caller-supplied and must already be one safe component. ``server_name``
+    comes from SIGAA's Content-Disposition, so it is sanitized rather than trusted.
+    """
+    if requested is not None:
+        if (
+            not requested
+            or Path(requested).name != requested
+            or sanitize_download_filename(requested) != requested
+        ):
+            raise ToolError("filename must be one safe file name, not a path")
+        name = requested
+    else:
+        name = sanitize_download_filename(server_name)
+
+    download_dir = default_download_dir().resolve()
+    target = download_dir / name
+    if target.exists() or target.is_symlink():
+        raise ToolError(f"download already exists: {name}")
+    download_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        return write_private_file(target, content)
+    except FileExistsError:
+        raise ToolError(f"download already exists: {name}") from None
+
+
 @mcp.tool()
-def sigaa_download_material(material_id: str, path: str | None = None) -> str:
+def sigaa_download_material(material_id: str, filename: str | None = None) -> str:
     """Download an uploaded class material (file) by its id. Networked. Returns the path written."""
     repo = _repo()
     material = next((m for m in repo.get_materials() if m.id == material_id), None)
@@ -156,11 +185,9 @@ def sigaa_download_material(material_id: str, path: str | None = None) -> str:
         turma = next((t for t in client.list_turmas() if t.id_turma == material.id_turma), None)
         if turma is None:
             return "could not locate the class for this material"
-        content, filename = client.download_material(turma, material_id)
-    out = path or filename
-    with open(out, "wb") as fh:
-        fh.write(content)
-    return f"wrote {out} ({len(content)} bytes)"
+        content, server_name = client.download_material(turma, material_id)
+    written = _write_downloaded_file(content, requested=filename, server_name=server_name)
+    return f"wrote {written} ({len(content)} bytes)"
 
 
 @mcp.tool()
@@ -436,7 +463,7 @@ def sigaa_get_tarefa_body(deadline_id: str) -> dict:
 
 
 @mcp.tool()
-def sigaa_download_tarefa_anexo(deadline_id: str, path: str | None = None) -> str:
+def sigaa_download_tarefa_anexo(deadline_id: str, filename: str | None = None) -> str:
     """Download a task's teacher attachment (Arquivo do Professor) by its deadline id.
     Networked. Returns the path written, or a message if the task has no attachment."""
     repo = _repo()
@@ -452,11 +479,9 @@ def sigaa_download_tarefa_anexo(deadline_id: str, path: str | None = None) -> st
         result = client.download_tarefa_attachment(deadline_id)
     if result is None:
         return "no teacher attachment on this task (or it is not a tarefa)"
-    content, filename = result
-    out = path or filename
-    with open(out, "wb") as fh:
-        fh.write(content)
-    return f"wrote {out} ({len(content)} bytes)"
+    content, server_name = result
+    written = _write_downloaded_file(content, requested=filename, server_name=server_name)
+    return f"wrote {written} ({len(content)} bytes)"
 
 
 @mcp.tool()

--- a/sigaa/mcp_server.py
+++ b/sigaa/mcp_server.py
@@ -21,7 +21,7 @@ from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import CallToolResult, ResourceLink, TextContent
 
 from .client import SigaaClient
-from .config import Settings, default_download_dir
+from .config import HOSTED_MODE, Settings, default_download_dir, default_mode
 from .curriculum import curriculum_to_dict
 from .documents import (
     ATESTADO_MATRICULA,
@@ -51,6 +51,19 @@ from .store.db import connect
 from .store.repository import Repository
 
 mcp = FastMCP("sigaa-ufpb")
+
+# Tools hidden in hosted mode. All five write files to the server's disk, and a shared
+# deployment has no per-tenant download directory yet, so none of them belong there.
+# Nothing is hidden in local mode: a self-hosted install keeps the full surface.
+HOSTED_HIDDEN_TOOLS = frozenset(
+    {
+        "sigaa_download_material",
+        "sigaa_download_tarefa_anexo",
+        "sigaa_download_historico",
+        "sigaa_download_declaracao_vinculo",
+        "sigaa_download_atestado_matricula",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -761,6 +774,29 @@ def sigaa_sync(fetch_bodies: bool = False) -> dict:
             for d in result.new_deadlines
         ],
     }
+
+
+def hidden_tools_for_mode(mode: str) -> frozenset[str]:
+    """Tool names to withhold in the given mode. Pure; the deny list lives here."""
+    return HOSTED_HIDDEN_TOOLS if mode == HOSTED_MODE else frozenset()
+
+
+def apply_mode(server: FastMCP, mode: str) -> None:
+    """Remove the tools the mode withholds.
+
+    remove_tool deletes from the tool manager, so a withheld tool is uncallable and not
+    merely hidden from tools/list. It raises on an unknown name, which keeps the deny
+    list from going stale after a rename.
+
+    The sigaa-document:// resource handlers stay registered in every mode. When their
+    minting tools are gone the token table stays empty and every read fails closed,
+    and FastMCP offers no remove_resource to unregister them with.
+    """
+    for name in sorted(hidden_tools_for_mode(mode)):
+        server.remove_tool(name)
+
+
+apply_mode(mcp, default_mode())
 
 
 def main() -> None:

--- a/sigaa/models.py
+++ b/sigaa/models.py
@@ -41,6 +41,20 @@ class Turma:
 
 
 @dataclass
+class Professor:
+    """A teacher of one turma, from the Turma Virtual 'Participantes' page.
+
+    Only the teaching staff is modelled; the enrolled students listed on the
+    same page are never parsed or stored.
+    """
+
+    id_turma: str
+    name: str
+    department: str | None = None
+    email: str | None = None
+
+
+@dataclass
 class NewsItem:
     """A class announcement. ``id`` is SIGAA's stable news id (dedup key)."""
 

--- a/sigaa/parsers/participantes.py
+++ b/sigaa/parsers/participantes.py
@@ -1,0 +1,88 @@
+"""Parse the Turma Virtual 'Participantes' page.
+
+Only the teaching staff is extracted. The page also lists every enrolled
+student (names and personal e-mail addresses); that block is deliberately
+never parsed or returned.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from bs4 import BeautifulSoup
+
+from ..models import Professor
+
+_PROFESSOR_LEGEND_RE = re.compile(r"professor(es)?\b")
+_DEPARTMENT_LABEL = "departamento"
+_EMAIL_LABEL = "e-mail"
+
+
+def parse_professors(html: str, id_turma: str) -> list[Professor]:
+    """Teaching staff listed under the 'Professores' fieldset of a turma."""
+    soup = BeautifulSoup(html, "lxml")
+    table = _professor_table(soup)
+    if table is None:
+        return []
+
+    professors: list[Professor] = []
+    for row in table.select("tr"):
+        name_el = row.select_one("strong")
+        name = name_el.get_text(" ", strip=True) if name_el else ""
+        if not name:
+            continue
+        fields = _labelled_fields(row)
+        professors.append(
+            Professor(
+                id_turma=id_turma,
+                name=name,
+                department=fields.get(_DEPARTMENT_LABEL),
+                email=fields.get(_EMAIL_LABEL),
+            )
+        )
+    return professors
+
+
+def _professor_table(soup: BeautifulSoup):
+    """The participantes table that follows the 'Professores (n)' legend.
+
+    SIGAA renders one table per role, each preceded by its own fieldset legend,
+    so the role is identified by the legend rather than by table position.
+    """
+    for legend in soup.select("fieldset legend"):
+        if not _PROFESSOR_LEGEND_RE.match(_normalized(legend.get_text(" ", strip=True))):
+            continue
+        table = legend.find_parent("fieldset").find_next("table", class_="participantes")
+        if table is not None:
+            return table
+    return None
+
+
+def _labelled_fields(row) -> dict[str, str]:
+    """Map each ``Label: <em>value</em>`` pair in the participant cell.
+
+    The label is a bare text node in front of the value's ``em``, so the pair is
+    recovered by walking back from each ``em`` rather than by line splitting.
+    """
+    fields: dict[str, str] = {}
+    for value_el in row.select("em"):
+        label = _preceding_label(value_el)
+        value = value_el.get_text(" ", strip=True)
+        if label and value:
+            fields.setdefault(label, value)
+    return fields
+
+
+def _preceding_label(value_el) -> str | None:
+    for node in value_el.previous_siblings:
+        text = _normalized(node.get_text(" ", strip=True) if hasattr(node, "get_text") else str(node))
+        if not text:
+            continue
+        return text.rstrip(":") if text.endswith(":") else None
+    return None
+
+
+def _normalized(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).replace("\xa0", " ")
+    return " ".join(normalized.split()).casefold()

--- a/sigaa/services/sync.py
+++ b/sigaa/services/sync.py
@@ -12,7 +12,16 @@ from dataclasses import dataclass, field
 
 from ..client import SigaaClient
 from ..config import Settings
-from ..models import Attendance, Deadline, Material, NewsItem, Student, Turma, TurmaGrade
+from ..models import (
+    Attendance,
+    Deadline,
+    Material,
+    NewsItem,
+    Professor,
+    Student,
+    Turma,
+    TurmaGrade,
+)
 from ..store.db import connect
 from ..store.repository import Repository
 
@@ -64,6 +73,7 @@ def sync(settings: Settings, fetch_bodies: bool = False) -> SyncResult:
                 result.attendance_updates.extend(
                     _sync_turma_attendance(client, repo, turma, turma_html)
                 )
+                _sync_turma_professors(client, repo, turma, turma_html)
 
             for deadline in client.list_deadlines():
                 if repo.upsert_deadline(deadline):
@@ -162,6 +172,19 @@ def _sync_turma_attendance(
     if attendance is None:
         return []
     return [attendance] if repo.upsert_attendance(attendance) else []
+
+
+def _sync_turma_professors(
+    client: SigaaClient, repo: Repository, turma: Turma, turma_html: str
+) -> list[Professor]:
+    """Best-effort: persist the turma's teaching staff (Participantes)."""
+    try:
+        professors = client.list_professors(turma, turma_html)
+    except Exception:  # noqa: BLE001 - per-turma participants page is optional
+        return []
+    if professors:
+        repo.replace_professors(turma.id_turma, professors)
+    return professors
 
 
 def _slug(text: str) -> str:

--- a/sigaa/services/sync.py
+++ b/sigaa/services/sync.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 import unicodedata
+from collections import Counter
 from dataclasses import dataclass, field
 
 from ..client import SigaaClient
@@ -24,6 +25,8 @@ from ..models import (
 )
 from ..store.db import connect
 from ..store.repository import Repository
+
+UNTITLED_EVALUATION_SLUG = "avaliacao"
 
 
 @dataclass
@@ -146,11 +149,17 @@ def _sync_turma_plan(
         return []
     if plan is None:
         return []
+    if plan.id_turma != turma.id_turma:
+        return []  # a plan that cannot be attributed to this turma is never stored
     fresh: list[Deadline] = []
+    seen: Counter[str] = Counter()
     for ev in plan.evaluations:
+        slug = _slug(ev.description) or UNTITLED_EVALUATION_SLUG
+        occurrence = seen[slug]
+        seen[slug] += 1
         deadline = Deadline(
-            id=f"plan:{plan.id_turma}:{ev.date}:{_slug(ev.description)}",
-            id_turma=plan.id_turma,
+            id=_plan_deadline_id(turma.id_turma, slug, occurrence),
+            id_turma=turma.id_turma,
             kind="avaliacao",
             title=ev.description,
             date=ev.date,
@@ -159,6 +168,17 @@ def _sync_turma_plan(
         if repo.upsert_deadline(deadline):
             fresh.append(deadline)
     return fresh
+
+
+def _plan_deadline_id(id_turma: str, slug: str, occurrence: int) -> str:
+    """Identify a plan evaluation by turma and evaluation, never by its date.
+
+    Teachers reschedule evaluations, so a date in the id turns every move into a
+    brand-new deadline. ``occurrence`` disambiguates a plan that lists the same
+    evaluation description more than once.
+    """
+    suffix = f":{occurrence}" if occurrence else ""
+    return f"plan:{id_turma}:{slug}{suffix}"
 
 
 def _sync_turma_attendance(

--- a/sigaa/setup_wizard.py
+++ b/sigaa/setup_wizard.py
@@ -111,16 +111,39 @@ def resolve_script(name: str) -> str:
     return str(Path(sys.executable).resolve().parent / f"{name}{suffix}")
 
 
-def merge_mcp_config(path: Path, *, command: str, username: str) -> bool:
+# Source uvx resolves the server from. Switch to "sigaa-tools[mcp]" once the
+# package is published to PyPI; the generated config keeps working either way.
+MCP_PACKAGE_SPEC = "sigaa-tools[mcp] @ git+https://github.com/PucaVaz/sigaa-tools"
+
+
+def build_mcp_server(*, username: str | None = None) -> dict[str, object]:
+    """Return an MCP server entry, preferring a portable ``uvx`` invocation.
+
+    Pass ``username`` only when keyring cannot store the active account; the
+    server otherwise reads it back itself, keeping the config free of personal
+    data so it can be committed alongside the project.
+    """
+    if shutil.which("uv"):
+        server: dict[str, object] = {
+            "command": "uvx",
+            "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
+        }
+    else:
+        server = {"command": resolve_script("sigaa-mcp")}
+    if username:
+        server["env"] = {"SIGAA_USER": username}
+    return server
+
+
+def merge_mcp_config(path: Path, *, server: dict[str, object]) -> bool:
     path = path.expanduser()
     if path.exists():
         data = json.loads(path.read_text(encoding="utf-8"))
     else:
         data = {}
     servers = data.setdefault("mcpServers", {})
-    desired = {"command": command, "env": {"SIGAA_USER": username}}
-    changed = servers.get("sigaa") != desired
-    servers["sigaa"] = desired
+    changed = servers.get("sigaa") != server
+    servers["sigaa"] = server
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     return changed
@@ -188,8 +211,10 @@ def run_init(settings: Settings, input_func: Callable[[str], str] = input) -> in
         default_mcp = Path.cwd() / ".mcp.json"
         answer = input_func(f"MCP config path [{default_mcp}]: ").strip()
         mcp_path = Path(answer).expanduser() if answer else default_mcp
-        command = resolve_script("sigaa-mcp")
-        merge_mcp_config(mcp_path, command=command, username=username)
+        # The active account comes back from keyring, so only pin it in the
+        # config when keyring could not store it.
+        server = build_mcp_server(username=None if login.password_stored else username)
+        merge_mcp_config(mcp_path, server=server)
         print(f"wrote MCP server config to {mcp_path}")
 
     if _confirm("Install scheduled sync? [y/N]: ", input_func):

--- a/sigaa/store/db.py
+++ b/sigaa/store/db.py
@@ -25,6 +25,15 @@ CREATE TABLE IF NOT EXISTS turma (
     updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE TABLE IF NOT EXISTS professor (
+    id_turma   TEXT NOT NULL REFERENCES turma(id_turma),
+    name       TEXT NOT NULL,
+    department TEXT,
+    email      TEXT,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (id_turma, name)
+);
+
 CREATE TABLE IF NOT EXISTS news (
     id         TEXT PRIMARY KEY,
     id_turma   TEXT NOT NULL REFERENCES turma(id_turma),

--- a/sigaa/store/db.py
+++ b/sigaa/store/db.py
@@ -136,6 +136,17 @@ def _migrate(conn: sqlite3.Connection) -> None:
     if not _has_column(conn, "deadline", "body"):
         conn.execute("ALTER TABLE deadline ADD COLUMN body TEXT")
         conn.commit()
+    _drop_legacy_plan_deadlines(conn)
+
+
+def _drop_legacy_plan_deadlines(conn: sqlite3.Connection) -> None:
+    """Remove plan deadlines keyed by date (``plan:<turma>:<dd/mm/yyyy>:<slug>``).
+
+    Those ids made a rescheduled evaluation look like a new deadline forever;
+    the current id is ``plan:<turma>:<slug>`` and is rebuilt on the next sync.
+    """
+    conn.execute("DELETE FROM deadline WHERE id GLOB 'plan:*:??/??/????:*'")
+    conn.commit()
 
 
 def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:

--- a/sigaa/store/repository.py
+++ b/sigaa/store/repository.py
@@ -12,6 +12,7 @@ from ..models import (
     Grade,
     Material,
     NewsItem,
+    Professor,
     Student,
     Turma,
     TurmaGrade,
@@ -61,6 +62,24 @@ class Repository:
             (code_or_id, code_or_id),
         ).fetchone()
         return _turma(row) if row else None
+
+    # --- professors ------------------------------------------------------
+    def replace_professors(self, id_turma: str, professors: list[Professor]) -> None:
+        """Set a class's teaching staff, dropping anyone no longer listed."""
+        self._conn.execute("DELETE FROM professor WHERE id_turma = ?", (id_turma,))
+        self._conn.executemany(
+            """INSERT INTO professor (id_turma, name, department, email, updated_at)
+               VALUES (?, ?, ?, ?, datetime('now'))""",
+            [(p.id_turma, p.name, p.department, p.email) for p in professors],
+        )
+        self._conn.commit()
+
+    def get_professors(self, id_turma: str | None = None) -> list[Professor]:
+        where, params = ("WHERE id_turma = ?", [id_turma]) if id_turma else ("", [])
+        rows = self._conn.execute(
+            f"SELECT * FROM professor {where} ORDER BY id_turma, name", params
+        ).fetchall()
+        return [_professor(r) for r in rows]
 
     # --- news ------------------------------------------------------------
     def known_news_ids(self, id_turma: str) -> set[str]:
@@ -348,6 +367,13 @@ def _turma(row: sqlite3.Row) -> Turma:
     return Turma(
         id_turma=row["id_turma"], name=row["name"], code=row["code"], room=row["room"],
         schedule_raw=row["schedule_raw"], semester=row["semester"],
+    )
+
+
+def _professor(row: sqlite3.Row) -> Professor:
+    return Professor(
+        id_turma=row["id_turma"], name=row["name"], department=row["department"],
+        email=row["email"],
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,18 +3,26 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
 
-def mcp_subprocess_env(download_dir: Path, **extra: str) -> dict[str, str]:
-    """Env for spawning `python -m sigaa.mcp_server` with no ambient credentials.
 
-    Keyring is nulled and the download dir is redirected into the test's tmp_path so a
-    spawned server can never reach the developer's real account or files.
+@pytest.fixture
+def mcp_subprocess_env():
+    """Factory for the env used to spawn `python -m sigaa.mcp_server` in tests.
+
+    Strips ambient credentials, nulls the keyring backend and redirects the download
+    directory into the test's tmp_path, so a spawned server can never reach the
+    developer's real account or files. Extra variables are passed as keywords.
     """
-    environment = dict(os.environ)
-    environment.pop("SIGAA_USER", None)
-    environment.pop("SIGAA_PASS", None)
-    environment.pop("SIGAA_MODE", None)
-    environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-    environment["SIGAA_DOWNLOAD_DIR"] = str(download_dir)
-    environment.update(extra)
-    return environment
+
+    def build(download_dir: Path, **extra: str) -> dict[str, str]:
+        environment = dict(os.environ)
+        environment.pop("SIGAA_USER", None)
+        environment.pop("SIGAA_PASS", None)
+        environment.pop("SIGAA_MODE", None)
+        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+        environment["SIGAA_DOWNLOAD_DIR"] = str(download_dir)
+        environment.update(extra)
+        return environment
+
+    return build

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def mcp_subprocess_env(download_dir: Path, **extra: str) -> dict[str, str]:
+    """Env for spawning `python -m sigaa.mcp_server` with no ambient credentials.
+
+    Keyring is nulled and the download dir is redirected into the test's tmp_path so a
+    spawned server can never reach the developer's real account or files.
+    """
+    environment = dict(os.environ)
+    environment.pop("SIGAA_USER", None)
+    environment.pop("SIGAA_PASS", None)
+    environment.pop("SIGAA_MODE", None)
+    environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
+    environment["SIGAA_DOWNLOAD_DIR"] = str(download_dir)
+    environment.update(extra)
+    return environment

--- a/tests/fixtures/participantes.html
+++ b/tests/fixtures/participantes.html
@@ -1,0 +1,54 @@
+<html>
+<body>
+<form id="j_id_jsp_1900130699_230" name="j_id_jsp_1900130699_230" method="post" action="/sigaa/ava/participantes.jsf">
+	<fieldset>
+		<legend> Professores (2)</legend></fieldset>
+		<table class="participantes">
+			<tr class="odd">
+				<td width="72" align="center">
+					<img src="/sigaa/verFoto?idFoto=1000001&amp;key=abc" width="60" height="75" />
+				</td>
+				<td valign="top">
+						<img src="/sigaa/img/portal_turma/offline.png" title="Usu&aacute;rio Off-Line no SIGAA" />
+						<strong>
+							<a href="http://www.ufpb.br/docente/exemplo" target="_blank" title="Acesse a p&#225;gina p&#250;blica deste docente" >CLARA DANTAS DE EXEMPLO</a>
+						</strong> <br/>
+						Departamento: <em>CI - DEPARTAMENTO DE INFORM&#193;TICA</em> <br/>
+						Forma&#231;&#227;o: <em>DOUTORADO</em> <br/>
+						E-Mail: <em>clara@ci.ufpb.br</em> <br/>
+						Breve resumo do curr&#237;culo do docente.
+				</td>
+			</tr>
+			<tr class="even">
+				<td width="72" align="center"></td>
+				<td valign="top">
+						<strong>SEGUNDO DOCENTE DE EXEMPLO</strong> <br/>
+						Departamento: <em>CI - DEPARTAMENTO DE SISTEMAS DE COMPUTA&#199;&#195;O</em> <br/>
+						Forma&#231;&#227;o: <em>MESTRADO</em> <br/>
+				</td>
+			</tr>
+		</table>
+		<br />
+		<fieldset>
+			<legend> Alunos (2)</legend>
+		</fieldset>
+			<input type="hidden" value="aluno.um@example.com, aluno.dois@example.com" id="emailsAlunos">
+			<table class="participantes">
+				<tr class="even">
+					<td width="47"></td>
+					<td valign="top">
+						<strong>ALUNO UM DE EXEMPLO</strong> <br/>
+						E-Mail: <em>aluno.um@example.com</em> <br/>
+					</td>
+				</tr>
+				<tr class="odd">
+					<td width="47"></td>
+					<td valign="top">
+						<strong>ALUNO DOIS DE EXEMPLO</strong> <br/>
+						E-Mail: <em>aluno.dois@example.com</em> <br/>
+					</td>
+				</tr>
+			</table>
+</form>
+</body>
+</html>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from sigaa.config import HOSTED_MODE, LOCAL_MODE, default_mode
+
+
+def test_mode_defaults_to_local_when_unset(monkeypatch):
+    monkeypatch.delenv("SIGAA_MODE", raising=False)
+
+    assert default_mode() == LOCAL_MODE
+
+
+def test_mode_defaults_to_local_when_empty(monkeypatch):
+    monkeypatch.setenv("SIGAA_MODE", "   ")
+
+    assert default_mode() == LOCAL_MODE
+
+
+def test_mode_reads_hosted_ignoring_case_and_padding(monkeypatch):
+    monkeypatch.setenv("SIGAA_MODE", "  HOSTED ")
+
+    assert default_mode() == HOSTED_MODE
+
+
+def test_mode_rejects_an_unknown_value(monkeypatch):
+    monkeypatch.setenv("SIGAA_MODE", "hosted-v2")
+
+    with pytest.raises(ValueError, match="SIGAA_MODE must be one of"):
+        default_mode()

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import stat
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+from sigaa import mcp_server
+
+MATERIAL_ID = "mat-1"
+MATERIAL_BYTES = b"slides for week one"
+
+
+def _configure(monkeypatch, tmp_path, *, server_name: str):
+    """Point the material downloader at fake credentials, a fake client and tmp_path."""
+    material = SimpleNamespace(id=MATERIAL_ID, kind="file", id_turma="369279", url=None)
+    turma = SimpleNamespace(id_turma="369279")
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def list_turmas(self):
+            return [turma]
+
+        def download_material(self, requested_turma, material_id):
+            assert requested_turma is turma
+            assert material_id == MATERIAL_ID
+            return MATERIAL_BYTES, server_name
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    monkeypatch.setattr(mcp_server, "_repo", lambda: SimpleNamespace(get_materials=lambda: [material]))
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+
+
+def test_material_download_rejects_a_caller_supplied_path(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="slides.pdf")
+
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server.sigaa_download_material(MATERIAL_ID, "../escape.bin")
+
+    assert not (tmp_path.parent / "escape.bin").exists()
+
+
+def test_material_download_sanitizes_a_hostile_server_filename(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="../../evil.bin")
+
+    message = mcp_server.sigaa_download_material(MATERIAL_ID)
+
+    assert not (tmp_path.parent / "evil.bin").exists()
+    written = [item for item in tmp_path.iterdir() if item.is_file()]
+    assert len(written) == 1
+    assert written[0].parent == tmp_path
+    assert written[0].read_bytes() == MATERIAL_BYTES
+    assert str(written[0]) in message
+
+
+def test_material_download_refuses_to_clobber_an_existing_file(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="slides.pdf")
+
+    mcp_server.sigaa_download_material(MATERIAL_ID)
+
+    with pytest.raises(ToolError, match="already exists"):
+        mcp_server.sigaa_download_material(MATERIAL_ID)
+
+    assert (tmp_path / "slides.pdf").read_bytes() == MATERIAL_BYTES
+
+
+def test_material_download_writes_a_private_contained_file(monkeypatch, tmp_path):
+    _configure(monkeypatch, tmp_path, server_name="slides.pdf")
+
+    message = mcp_server.sigaa_download_material(MATERIAL_ID, "aula-01.pdf")
+
+    target = tmp_path / "aula-01.pdf"
+    assert target.read_bytes() == MATERIAL_BYTES
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert str(target) in message
+    assert str(len(MATERIAL_BYTES)) in message

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -42,7 +42,8 @@ def _configure(monkeypatch, tmp_path, *, server_name: str):
     settings = SimpleNamespace(
         username="configured-user", resolve_password=lambda: "test-password"
     )
-    monkeypatch.setattr(mcp_server, "_repo", lambda: SimpleNamespace(get_materials=lambda: [material]))
+    repo = SimpleNamespace(get_materials=lambda: [material])
+    monkeypatch.setattr(mcp_server, "_repo", lambda: repo)
     monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
     monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
     monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)

--- a/tests/test_mcp_downloads.py
+++ b/tests/test_mcp_downloads.py
@@ -92,3 +92,93 @@ def test_material_download_writes_a_private_contained_file(monkeypatch, tmp_path
     assert stat.S_IMODE(target.stat().st_mode) == 0o600
     assert str(target) in message
     assert str(len(MATERIAL_BYTES)) in message
+
+
+DEADLINE_ID = "dl-1"
+ATTACHMENT_BYTES = b"assignment brief"
+
+
+def _configure_attachment(monkeypatch, tmp_path, *, server_name: str, result_present: bool = True):
+    """Point the attachment downloader at fake credentials, a fake client and tmp_path."""
+    deadline = SimpleNamespace(id=DEADLINE_ID, kind="tarefa", title="Tarefa 1")
+
+    class FakeClient:
+        def __init__(self, username, password):
+            assert username == "configured-user"
+            assert password == "test-password"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return None
+
+        def download_tarefa_attachment(self, deadline_id):
+            assert deadline_id == DEADLINE_ID
+            if not result_present:
+                return None
+            return ATTACHMENT_BYTES, server_name
+
+    settings = SimpleNamespace(
+        username="configured-user", resolve_password=lambda: "test-password"
+    )
+    repo = SimpleNamespace(get_deadlines=lambda: [deadline])
+    monkeypatch.setattr(mcp_server, "_repo", lambda: repo)
+    monkeypatch.setattr(mcp_server, "Settings", lambda: settings)
+    monkeypatch.setattr(mcp_server, "SigaaClient", FakeClient)
+    monkeypatch.setattr(mcp_server, "default_download_dir", lambda: tmp_path)
+
+
+def test_attachment_download_rejects_a_caller_supplied_path(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="brief.pdf")
+
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID, "../escape.bin")
+
+    assert not (tmp_path.parent / "escape.bin").exists()
+
+
+def test_attachment_download_sanitizes_a_hostile_server_filename(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="../../evil.bin")
+
+    message = mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID)
+
+    assert not (tmp_path.parent / "evil.bin").exists()
+    written = [item for item in tmp_path.iterdir() if item.is_file()]
+    assert len(written) == 1
+    assert written[0].read_bytes() == ATTACHMENT_BYTES
+    assert str(written[0]) in message
+
+
+def test_attachment_download_writes_a_private_contained_file(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="brief.pdf")
+
+    message = mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID, "tarefa-01.pdf")
+
+    target = tmp_path / "tarefa-01.pdf"
+    assert target.read_bytes() == ATTACHMENT_BYTES
+    assert stat.S_IMODE(target.stat().st_mode) == 0o600
+    assert str(target) in message
+
+
+def test_attachment_download_rejects_the_filename_before_touching_the_network(
+    monkeypatch, tmp_path
+):
+    """An unsafe name must fail even when the deadline lookup would have failed too."""
+
+    def explode():
+        raise AssertionError("must not reach the store with an unsafe filename")
+
+    monkeypatch.setattr(mcp_server, "_repo", lambda: explode())
+
+    with pytest.raises(ToolError, match="safe file name"):
+        mcp_server.sigaa_download_tarefa_anexo("unknown", "../escape.bin")
+
+
+def test_attachment_download_reports_a_task_with_no_attachment(monkeypatch, tmp_path):
+    _configure_attachment(monkeypatch, tmp_path, server_name="brief.pdf", result_present=False)
+
+    message = mcp_server.sigaa_download_tarefa_anexo(DEADLINE_ID)
+
+    assert "no teacher attachment" in message
+    assert list(tmp_path.iterdir()) == []

--- a/tests/test_mcp_mode.py
+++ b/tests/test_mcp_mode.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from sigaa import mcp_server
+from sigaa.config import HOSTED_MODE, LOCAL_MODE
+from tests.conftest import mcp_subprocess_env
+
+KEPT_IN_HOSTED = {"sigaa_sync", "sigaa_list_classes", "sigaa_matricula_open_turmas"}
+
+
+def _spawn(environment):
+    return StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "sigaa.mcp_server"],
+        env=environment,
+    )
+
+
+def test_local_mode_hides_nothing():
+    assert mcp_server.hidden_tools_for_mode(LOCAL_MODE) == frozenset()
+
+
+def test_hosted_mode_hides_the_disk_writers():
+    assert mcp_server.hidden_tools_for_mode(HOSTED_MODE) == mcp_server.HOSTED_HIDDEN_TOOLS
+
+
+def test_deny_list_only_names_tools_that_exist():
+    """A renamed tool must not leave a stale entry behind — remove_tool would raise."""
+    assert mcp_server.HOSTED_HIDDEN_TOOLS <= set(mcp_server.mcp._tool_manager._tools)
+
+
+def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path):
+    async def exercise_server():
+        environment = mcp_subprocess_env(tmp_path, SIGAA_MODE="hosted")
+
+        async with stdio_client(_spawn(environment)) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = {tool.name for tool in (await session.list_tools()).tools}
+
+                assert listed.isdisjoint(mcp_server.HOSTED_HIDDEN_TOOLS)
+                assert KEPT_IN_HOSTED <= listed
+
+                # Proves the tool is gone, not merely hidden: call_tool dispatches
+                # straight into the tool manager, bypassing any list_tools filter.
+                refused = await session.call_tool(
+                    "sigaa_download_material", {"material_id": "any"}
+                )
+                assert refused.isError is True
+                assert "Unknown tool" in " ".join(
+                    getattr(item, "text", "") for item in refused.content
+                )
+
+    asyncio.run(exercise_server())
+
+
+def test_default_server_still_exposes_every_tool(tmp_path):
+    """No behavior change for existing users: unset SIGAA_MODE keeps the full surface."""
+
+    async def exercise_server():
+        environment = mcp_subprocess_env(tmp_path)
+
+        async with stdio_client(_spawn(environment)) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = {tool.name for tool in (await session.list_tools()).tools}
+
+                assert mcp_server.HOSTED_HIDDEN_TOOLS <= listed
+
+    asyncio.run(exercise_server())

--- a/tests/test_mcp_mode.py
+++ b/tests/test_mcp_mode.py
@@ -12,7 +12,6 @@ from mcp.client.stdio import stdio_client
 
 from sigaa import mcp_server
 from sigaa.config import HOSTED_MODE, LOCAL_MODE
-from tests.conftest import mcp_subprocess_env
 
 KEPT_IN_HOSTED = {"sigaa_sync", "sigaa_list_classes", "sigaa_matricula_open_turmas"}
 
@@ -38,7 +37,7 @@ def test_deny_list_only_names_tools_that_exist():
     assert mcp_server.HOSTED_HIDDEN_TOOLS <= set(mcp_server.mcp._tool_manager._tools)
 
 
-def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path):
+def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path, mcp_subprocess_env):
     async def exercise_server():
         environment = mcp_subprocess_env(tmp_path, SIGAA_MODE="hosted")
 
@@ -63,7 +62,7 @@ def test_hosted_server_withholds_downloads_and_keeps_the_rest(tmp_path):
     asyncio.run(exercise_server())
 
 
-def test_default_server_still_exposes_every_tool(tmp_path):
+def test_default_server_still_exposes_every_tool(tmp_path, mcp_subprocess_env):
     """No behavior change for existing users: unset SIGAA_MODE keeps the full surface."""
 
     async def exercise_server():

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import sys
 
 import pytest
@@ -11,14 +10,12 @@ pytest.importorskip("mcp")
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
+from tests.conftest import mcp_subprocess_env
+
 
 def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
     async def exercise_server():
-        environment = dict(os.environ)
-        environment.pop("SIGAA_USER", None)
-        environment.pop("SIGAA_PASS", None)
-        environment["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
-        environment["SIGAA_DOWNLOAD_DIR"] = str(tmp_path)
+        environment = mcp_subprocess_env(tmp_path)
         parameters = StdioServerParameters(
             command=sys.executable,
             args=["-m", "sigaa.mcp_server"],
@@ -53,3 +50,36 @@ def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
 
     asyncio.run(exercise_server())
     assert not (tmp_path.parent / "outside.pdf").exists()
+
+
+def test_mcp_stdio_rejects_a_path_in_the_material_download_filename(tmp_path):
+    async def exercise_server():
+        environment = mcp_subprocess_env(tmp_path)
+        parameters = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "sigaa.mcp_server"],
+            env=environment,
+        )
+
+        async with stdio_client(parameters) as (read_stream, write_stream):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                listed = await session.list_tools()
+                downloaders = {
+                    tool.name: tool
+                    for tool in listed.tools
+                    if tool.name in {"sigaa_download_material", "sigaa_download_tarefa_anexo"}
+                }
+                assert len(downloaders) == 2
+                for tool in downloaders.values():
+                    assert "filename" in tool.inputSchema.get("properties", {})
+                    assert "path" not in tool.inputSchema.get("properties", {})
+
+                rejected = await session.call_tool(
+                    "sigaa_download_material",
+                    {"material_id": "any", "filename": "../outside.bin"},
+                )
+                assert rejected.isError is True
+
+    asyncio.run(exercise_server())
+    assert not (tmp_path.parent / "outside.bin").exists()

--- a/tests/test_mcp_protocol.py
+++ b/tests/test_mcp_protocol.py
@@ -10,10 +10,8 @@ pytest.importorskip("mcp")
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from tests.conftest import mcp_subprocess_env
 
-
-def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
+def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path, mcp_subprocess_env):
     async def exercise_server():
         environment = mcp_subprocess_env(tmp_path)
         parameters = StdioServerParameters(
@@ -52,7 +50,7 @@ def test_mcp_stdio_exposes_safe_document_schemas_and_errors(tmp_path):
     assert not (tmp_path.parent / "outside.pdf").exists()
 
 
-def test_mcp_stdio_rejects_a_path_in_the_material_download_filename(tmp_path):
+def test_mcp_stdio_rejects_a_path_in_the_material_download_filename(tmp_path, mcp_subprocess_env):
     async def exercise_server():
         environment = mcp_subprocess_env(tmp_path)
         parameters = StdioServerParameters(

--- a/tests/test_participantes.py
+++ b/tests/test_participantes.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+from sigaa.parsers import participantes as participantes_parser
+from sigaa.store.db import connect
+from sigaa.store.repository import Repository
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PARTICIPANTES = (FIXTURES / "participantes.html").read_text(encoding="utf-8")
+ID_TURMA = "379201"
+
+
+def test_parse_professors_reads_name_department_and_email():
+    professors = participantes_parser.parse_professors(PARTICIPANTES, ID_TURMA)
+
+    assert [p.name for p in professors] == [
+        "CLARA DANTAS DE EXEMPLO",
+        "SEGUNDO DOCENTE DE EXEMPLO",
+    ]
+    assert all(p.id_turma == ID_TURMA for p in professors)
+
+    first = professors[0]
+    assert first.department == "CI - DEPARTAMENTO DE INFORMÁTICA"
+    assert first.email == "clara@ci.ufpb.br"
+
+    # A teacher without a listed e-mail keeps the field empty rather than
+    # borrowing the next labelled value.
+    assert professors[1].email is None
+
+
+def test_parse_professors_ignores_the_student_roster():
+    professors = participantes_parser.parse_professors(PARTICIPANTES, ID_TURMA)
+
+    names = {p.name for p in professors}
+    emails = {p.email for p in professors}
+    assert "ALUNO UM DE EXEMPLO" not in names
+    assert "aluno.um@example.com" not in emails
+
+
+def test_parse_professors_without_the_fieldset_returns_empty():
+    assert participantes_parser.parse_professors("<html></html>", ID_TURMA) == []
+
+
+def test_replace_professors_is_idempotent_and_drops_removed_staff(tmp_path):
+    conn = connect(tmp_path / "sigaa.db")
+    repo = Repository(conn)
+    conn.execute("INSERT INTO turma (id_turma, code, name) VALUES (?, 'X', 'X')", (ID_TURMA,))
+
+    professors = participantes_parser.parse_professors(PARTICIPANTES, ID_TURMA)
+    repo.replace_professors(ID_TURMA, professors)
+    repo.replace_professors(ID_TURMA, professors)
+    assert len(repo.get_professors(ID_TURMA)) == 2
+
+    repo.replace_professors(ID_TURMA, professors[:1])
+    stored = repo.get_professors(ID_TURMA)
+    assert [p.name for p in stored] == ["CLARA DANTAS DE EXEMPLO"]
+    assert stored[0].email == "clara@ci.ufpb.br"
+    conn.close()

--- a/tests/test_participantes.py
+++ b/tests/test_participantes.py
@@ -55,3 +55,19 @@ def test_replace_professors_is_idempotent_and_drops_removed_staff(tmp_path):
     assert [p.name for p in stored] == ["CLARA DANTAS DE EXEMPLO"]
     assert stored[0].email == "clara@ci.ufpb.br"
     conn.close()
+
+
+def test_filter_by_professor_ignores_accents_and_case():
+    from types import SimpleNamespace
+
+    from sigaa.cli import _filter_by_professor
+
+    turmas = [SimpleNamespace(id_turma="1"), SimpleNamespace(id_turma="2")]
+    professors = {
+        "1": [SimpleNamespace(name="JOSÉ ANTÔNIO DA SILVA")],
+        "2": [SimpleNamespace(name="MARIA CLARA")],
+    }
+
+    assert [t.id_turma for t in _filter_by_professor(turmas, professors, "jose antonio")] == ["1"]
+    assert [t.id_turma for t in _filter_by_professor(turmas, professors, "Antônio")] == ["1"]
+    assert _filter_by_professor(turmas, professors, "nobody") == []

--- a/tests/test_plan_deadlines.py
+++ b/tests/test_plan_deadlines.py
@@ -1,5 +1,36 @@
-from sigaa.services.sync import _slug
-from sigaa.models import CoursePlan, PlanEvaluation
+from pathlib import Path
+
+from sigaa.models import CoursePlan, PlanEvaluation, Turma
+from sigaa.parsers.plano import parse_course_plan
+from sigaa.services.sync import _plan_deadline_id, _slug, _sync_turma_plan
+from sigaa.store.db import connect
+from sigaa.store.repository import Repository
+
+FIXTURES = Path(__file__).parent / "fixtures"
+PLANO = (FIXTURES / "plano.html").read_text(encoding="utf-8")
+ID_TURMA = "369279"
+OTHER_ID_TURMA = "379107"
+
+
+class _StubClient:
+    """Returns a canned plan for every turma, like a bounced Turma Virtual would."""
+
+    def __init__(self, plan: CoursePlan | None):
+        self.plan = plan
+
+    def get_course_plan(self, turma: Turma, turma_html: str | None = None) -> CoursePlan | None:
+        return self.plan
+
+
+def _repo(tmp_path, *id_turmas: str) -> Repository:
+    repo = Repository(connect(tmp_path / "t.db"))
+    for id_turma in id_turmas or (ID_TURMA,):
+        repo.upsert_turma(Turma(id_turma=id_turma, name="SD", code="DSCO00022"))
+    return repo
+
+
+def _turma(id_turma: str = ID_TURMA) -> Turma:
+    return Turma(id_turma=id_turma, name="SD", code="DSCO00022")
 
 
 def test_slug_normalizes_accents_and_spaces():
@@ -7,11 +38,87 @@ def test_slug_normalizes_accents_and_spaces():
     assert _slug("Exame Final") == "exame-final"
 
 
-def test_plan_evaluation_deadline_ids_are_stable():
-    plan = CoursePlan(
-        id_turma="369279",
-        evaluations=[PlanEvaluation(date="11/06/2026", description="1ª avaliação")],
+def test_plan_deadline_ids_are_scoped_to_the_turma():
+    assert _plan_deadline_id(ID_TURMA, _slug("1ª avaliação"), 0) == "plan:369279:1a-avaliacao"
+    assert _plan_deadline_id(OTHER_ID_TURMA, _slug("1ª avaliação"), 0) != _plan_deadline_id(
+        ID_TURMA, _slug("1ª avaliação"), 0
     )
-    ev = plan.evaluations[0]
-    deadline_id = f"plan:{plan.id_turma}:{ev.date}:{_slug(ev.description)}"
-    assert deadline_id == "plan:369279:11/06/2026:1a-avaliacao"
+
+
+def test_plan_deadline_id_ignores_the_evaluation_date():
+    """A rescheduled evaluation keeps its identity instead of looking brand new."""
+    assert _plan_deadline_id(ID_TURMA, "exame-final", 0) == "plan:369279:exame-final"
+
+
+def test_repeated_evaluation_descriptions_get_distinct_ids():
+    first = _plan_deadline_id(ID_TURMA, "reposicao", 0)
+    second = _plan_deadline_id(ID_TURMA, "reposicao", 1)
+    assert first != second
+
+
+def test_syncing_the_same_plan_twice_yields_no_new_deadlines(tmp_path):
+    repo = _repo(tmp_path)
+    client = _StubClient(parse_course_plan(PLANO, ID_TURMA))
+    first = _sync_turma_plan(client, repo, _turma(), PLANO)
+    assert len(first) == 5
+    assert _sync_turma_plan(client, repo, _turma(), PLANO) == []
+
+
+def test_rescheduled_evaluation_updates_in_place(tmp_path):
+    repo = _repo(tmp_path)
+    plan = CoursePlan(
+        id_turma=ID_TURMA,
+        evaluations=[PlanEvaluation(date="17/12/2026", description="Exame Final")],
+    )
+    assert len(_sync_turma_plan(_StubClient(plan), repo, _turma(), PLANO)) == 1
+
+    moved = CoursePlan(
+        id_turma=ID_TURMA,
+        evaluations=[PlanEvaluation(date="21/12/2026", description="Exame Final")],
+    )
+    assert _sync_turma_plan(_StubClient(moved), repo, _turma(), PLANO) == []
+    stored = repo.get_deadlines(id_turma=ID_TURMA)
+    assert len(stored) == 1
+    assert stored[0].date == "21/12/2026"
+
+
+def test_plan_from_another_turma_is_refused(tmp_path):
+    """A page that cannot be attributed to this turma must not be persisted."""
+    repo = _repo(tmp_path, ID_TURMA, OTHER_ID_TURMA)
+    plan = CoursePlan(
+        id_turma=OTHER_ID_TURMA,
+        evaluations=[PlanEvaluation(date="17/12/2026", description="Exame Final")],
+    )
+    assert _sync_turma_plan(_StubClient(plan), repo, _turma(ID_TURMA), PLANO) == []
+    assert repo.get_deadlines() == []
+
+
+def test_plan_rows_do_not_leak_across_turmas(tmp_path):
+    repo = _repo(tmp_path, ID_TURMA, OTHER_ID_TURMA)
+    for id_turma in (ID_TURMA, OTHER_ID_TURMA):
+        plan = parse_course_plan(PLANO, id_turma)
+        _sync_turma_plan(_StubClient(plan), repo, _turma(id_turma), PLANO)
+
+    mine = repo.get_deadlines(id_turma=ID_TURMA)
+    theirs = repo.get_deadlines(id_turma=OTHER_ID_TURMA)
+    assert len(mine) == len(theirs) == 5
+    assert all(d.id.startswith(f"plan:{ID_TURMA}:") for d in mine)
+    assert all(d.id.startswith(f"plan:{OTHER_ID_TURMA}:") for d in theirs)
+
+
+def test_legacy_date_keyed_plan_deadlines_are_dropped_on_connect(tmp_path):
+    db = tmp_path / "t.db"
+    repo = _repo(tmp_path)
+    repo._conn.execute(
+        "INSERT INTO deadline (id, id_turma, kind, title, date) VALUES (?, ?, ?, ?, ?)",
+        (f"plan:{ID_TURMA}:17/12/2026:exame-final", ID_TURMA, "avaliacao", "Exame Final", "17/12/2026"),
+    )
+    repo._conn.execute(
+        "INSERT INTO deadline (id, id_turma, kind, title, date) VALUES (?, ?, ?, ?, ?)",
+        ("portal-event-1", ID_TURMA, "avaliacao", "Prova", "11/06/2026"),
+    )
+    repo._conn.commit()
+    repo._conn.close()
+
+    survivors = [d.id for d in Repository(connect(db)).get_deadlines()]
+    assert survivors == ["portal-event-1"]

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -6,8 +6,10 @@ from types import SimpleNamespace
 from sigaa import setup_wizard
 from sigaa.config import KEYRING_ACTIVE_USERNAME, KEYRING_SERVICE, Settings
 from sigaa.setup_wizard import (
+    MCP_PACKAGE_SPEC,
     build_cron_line,
     build_launchd_plist,
+    build_mcp_server,
     merge_mcp_config,
     resolve_script,
 )
@@ -57,6 +59,34 @@ def test_login_persists_username_for_the_next_process(monkeypatch):
     ]
 
 
+def test_build_mcp_server_prefers_uvx_when_uv_is_installed(monkeypatch):
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: "/opt/bin/uv")
+
+    assert build_mcp_server() == {
+        "command": "uvx",
+        "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
+    }
+
+
+def test_build_mcp_server_falls_back_to_console_script_without_uv(monkeypatch):
+    monkeypatch.setattr(
+        "sigaa.setup_wizard.shutil.which",
+        lambda name: None if name == "uv" else f"/opt/bin/{name}",
+    )
+
+    assert build_mcp_server() == {"command": "/opt/bin/sigaa-mcp"}
+
+
+def test_build_mcp_server_sets_username_only_when_keyring_cannot_hold_it(monkeypatch):
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: "/opt/bin/uv")
+
+    assert build_mcp_server(username="alice") == {
+        "command": "uvx",
+        "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
+        "env": {"SIGAA_USER": "alice"},
+    }
+
+
 def test_merge_mcp_config_preserves_existing_servers(tmp_path):
     path = tmp_path / ".mcp.json"
     path.write_text(
@@ -71,32 +101,80 @@ def test_merge_mcp_config_preserves_existing_servers(tmp_path):
         encoding="utf-8",
     )
 
-    changed = merge_mcp_config(path, command="/opt/bin/sigaa-mcp", username="alice")
+    changed = merge_mcp_config(path, server={"command": "uvx", "args": ["sigaa-mcp"]})
 
     assert changed is True
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["mcpServers"]["other"] == {"command": "/bin/other"}
-    assert data["mcpServers"]["sigaa"] == {
-        "command": "/opt/bin/sigaa-mcp",
-        "env": {"SIGAA_USER": "alice"},
-    }
+    assert data["mcpServers"]["sigaa"] == {"command": "uvx", "args": ["sigaa-mcp"]}
 
 
 def test_merge_mcp_config_creates_parent_and_file(tmp_path):
     path = tmp_path / "project" / ".mcp.json"
 
-    changed = merge_mcp_config(path, command="/opt/bin/sigaa-mcp", username="alice")
+    changed = merge_mcp_config(path, server={"command": "/opt/bin/sigaa-mcp"})
 
     assert changed is True
     data = json.loads(path.read_text(encoding="utf-8"))
-    assert data == {
-        "mcpServers": {
-            "sigaa": {
-                "command": "/opt/bin/sigaa-mcp",
-                "env": {"SIGAA_USER": "alice"},
-            }
-        }
+    assert data == {"mcpServers": {"sigaa": {"command": "/opt/bin/sigaa-mcp"}}}
+
+
+def test_merge_mcp_config_reports_unchanged_when_server_already_matches(tmp_path):
+    path = tmp_path / ".mcp.json"
+    server = {"command": "uvx", "args": ["sigaa-mcp"]}
+    merge_mcp_config(path, server=server)
+
+    assert merge_mcp_config(path, server=server) is False
+
+
+def _run_init_writing_mcp(monkeypatch, tmp_path, *, password_stored: bool) -> dict:
+    """Drive run_init far enough to write .mcp.json, declining everything else."""
+    login = setup_wizard.LoginResult(
+        name="ALICE",
+        matricula="00000000000",
+        password_stored=password_stored,
+        storage_message="stored",
+        password="test-password",
+    )
+    monkeypatch.setattr(setup_wizard, "_prompt_login_until_ok", lambda *a, **k: login)
+    monkeypatch.setattr(
+        setup_wizard,
+        "sync",
+        lambda settings: SimpleNamespace(ok=True, turma_count=1, new_items=[], error=None),
+    )
+    monkeypatch.setattr("sigaa.setup_wizard.shutil.which", lambda name: "/opt/bin/uv")
+
+    mcp_path = tmp_path / ".mcp.json"
+    answers = ["1"]  # institution
+    if not password_stored:
+        answers.append("n")  # .env template, only offered when keyring failed
+    answers += [
+        "y",  # wire MCP
+        str(mcp_path),  # config path
+        "n",  # scheduled sync
+    ]
+    replies = iter(answers)
+    settings = Settings(db_path=tmp_path / "sigaa.db", username="alice")
+
+    assert setup_wizard.run_init(settings, lambda _prompt: next(replies)) == 0
+
+    return json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]["sigaa"]
+
+
+def test_run_init_writes_mcp_config_without_personal_data(monkeypatch, tmp_path):
+    server = _run_init_writing_mcp(monkeypatch, tmp_path, password_stored=True)
+
+    assert "env" not in server
+    assert server == {
+        "command": "uvx",
+        "args": ["--from", MCP_PACKAGE_SPEC, "sigaa-mcp"],
     }
+
+
+def test_run_init_pins_username_when_keyring_is_unavailable(monkeypatch, tmp_path):
+    server = _run_init_writing_mcp(monkeypatch, tmp_path, password_stored=False)
+
+    assert server["env"] == {"SIGAA_USER": "alice"}
 
 
 def test_build_launchd_plist_uses_resolved_command_and_username():

--- a/tests/test_turma_postback_isolation.py
+++ b/tests/test_turma_postback_isolation.py
@@ -1,0 +1,88 @@
+"""A cached Principal page feeds exactly one Turma Virtual postback.
+
+Chaining a second postback off the same page leaves the session on the page the
+first postback opened, so SIGAA answers with whatever turma it currently sits on
+-- the mechanism behind plan rows landing on the wrong turma.
+"""
+
+from sigaa import config
+from sigaa.client import SigaaClient
+from sigaa.models import Turma
+
+TURMA = Turma(id_turma="369279", name="SD", form_id="form", field="form:turma")
+
+PORTAL = (
+    '<html><body><form id="j_id_jsp_1_1">'
+    '<input id="javax.faces.ViewState" name="javax.faces.ViewState" value="j_id1"/>'
+    "</form></body></html>"
+)
+
+
+def _principal(marker: str) -> str:
+    menu = "".join(
+        f"""<a href="#" onclick="jsfcljs(document.getElementById('formMenu'),"""
+        f"""{{'menu:{slug}':'menu:{slug}'}},'');">{label}</a>"""
+        for label, slug in (("Ver Notas", "notas"), ("Plano de Curso", "plano"))
+    )
+    return (
+        f'<html><body data-page="{marker}"><form id="formMenu">{menu}'
+        '<input id="javax.faces.ViewState" name="javax.faces.ViewState" value="j_id2"/>'
+        "</form></body></html>"
+    )
+
+
+class _FakeSession:
+    def __init__(self):
+        self.posts: list[tuple[str, dict]] = []
+        self.enters = 0
+
+    def post(self, url: str, fields: dict) -> str:
+        self.posts.append((url, fields))
+        if url == config.PORTAL_ACTION_URL:
+            self.enters += 1
+            return _principal(f"re-entered-{self.enters}")
+        return "<html><body>menu response</body></html>"
+
+
+def _client() -> tuple[SigaaClient, _FakeSession]:
+    client = SigaaClient.__new__(SigaaClient)
+    session = _FakeSession()
+    client._session = session
+    client._portal_html = PORTAL
+    client._spent_principals = set()
+    return client, session
+
+
+def test_first_postback_reuses_the_cached_principal_page():
+    client, session = _client()
+    client.get_turma_grades(TURMA, _principal("cached"))
+    assert session.enters == 0
+    assert session.posts[0][0] == config.AVA_URL
+
+
+def test_second_postback_re_enters_the_turma():
+    client, session = _client()
+    cached = _principal("cached")
+    client.get_turma_grades(TURMA, cached)
+    client.get_course_plan(TURMA, cached)
+
+    assert session.enters == 1
+    enter_url, enter_fields = session.posts[1]
+    assert enter_url == config.PORTAL_ACTION_URL
+    assert enter_fields["idTurma"] == TURMA.id_turma
+
+
+def test_news_body_after_a_menu_postback_re_enters_the_turma():
+    client, session = _client()
+    cached = _principal("cached")
+    client.get_course_plan(TURMA, cached)
+    client.get_news_body(TURMA, "1", cached)
+
+    assert session.enters == 1
+
+
+def test_a_freshly_entered_page_is_usable_for_one_postback():
+    client, session = _client()
+    fresh = client.enter_turma(TURMA)
+    client.get_course_plan(TURMA, fresh)
+    assert session.enters == 1  # only the explicit enter_turma

--- a/uv.lock
+++ b/uv.lock
@@ -926,6 +926,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.16.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/7c/6adb35d70e7c027e308274557901c7e00fb3407750faf3620c184ae058cb/ruff-0.16.6.tar.gz", hash = "sha256:dcf8a73d2ff77e99dde91244b4da16feba7f14e6beeb4015dee7c5a909e99050", size = 4921251, upload-time = "2026-09-03T16:57:29.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/28/9cc1b79639e284ec103f43c88c644db4eb58cbd0ea1ca11f1193435369ac/ruff-0.16.6-py3-none-linux_armv6l.whl", hash = "sha256:61c368c26bf8e973e5ab14a2772de587bc068ea3f9a277f673380749b4898fb8", size = 10015638, upload-time = "2026-09-03T16:56:40.986Z" },
+    { url = "https://files.pythonhosted.org/packages/71/11/627d342ef727ea7794edf74fe23d60a074b02c3acc2e9436684e782286ca/ruff-0.16.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ecf4f068e2e123e43a26e9db4e19524cc56563912404e83bbfca375757e45a32", size = 10220762, upload-time = "2026-09-03T16:56:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d9/b75668ce41e4c8d073d18d6d08672ba6906ce45d5c06ea4fdb2e84ce3853/ruff-0.16.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:99b62ea33baf130f50368798d841f0d95527b6d817bf31817b65dd058f1d314c", size = 9835082, upload-time = "2026-09-03T16:56:47.142Z" },
+    { url = "https://files.pythonhosted.org/packages/99/97/123ab10b05cde889c107c20f5a9774955104b5552796a2a8584b089ae8eb/ruff-0.16.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7fbf89013f2bb3f6835a6038ff658dc8a1b38c98dc8e724b964168ad4e881876", size = 9949304, upload-time = "2026-09-03T16:56:49.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/58/a4a2c59dd2e5b85929c912d9cac3056eb9ee8c7e75e9b9fe3e109174966b/ruff-0.16.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56a67065e22efa6bc4d498299d3bb06c0c90aace8fac2068b5a12f9dc4d8d51d", size = 9840612, upload-time = "2026-09-03T16:56:52.368Z" },
+    { url = "https://files.pythonhosted.org/packages/61/6a/ff8c8626a786c4f49d48ced4a752dadbca65f5263005f9c2416578194694/ruff-0.16.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e25cc89174874b176a157e4428d66761c2c0c006654419bf384f967f361ff1b1", size = 10543465, upload-time = "2026-09-03T16:56:55.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/bb/c47535923365f337b82e28192e4e9eef2176511007cfd99a62fc22df5dad/ruff-0.16.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0700580ed5303723cb3c11c2f1d2a8913ce77b7ea86646dddb887f5417a9ba70", size = 11267576, upload-time = "2026-09-03T16:56:57.791Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/50/e5119a5212b5cd63b51e1f4b25e7bd636a6668fc069a3160b108ad7e3c16/ruff-0.16.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:15f1d0b6e165a6e56567befb6629f8209271311d990bae0f37e6d065035ef5f3", size = 10781993, upload-time = "2026-09-03T16:57:00.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/98/083d8b4ef3c51a0d19db84367791cbe9f44e4b53343d19dfa83556e1cd9a/ruff-0.16.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d72c591a96986ee4268860e2b7235082129ca5e4cb9cbba653a4b57c11893757", size = 10317748, upload-time = "2026-09-03T16:57:03.428Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/29/68f7ff2c5ad95f19f00627ac2de95644e25fe47371ea60b2db1fd952315e/ruff-0.16.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:65a006baa18f33324325814c864daef03541d51564b98c517610ea756ab7003e", size = 10540096, upload-time = "2026-09-03T16:57:06.182Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/79a8f6de85968641d68a7863aeec577551924ef066a990a48ff93167beab/ruff-0.16.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cd02a7bf1a21a8735228a3e8c95a9dc5cf86bd2a52194f4aaae2a5755b4de0f4", size = 10100494, upload-time = "2026-09-03T16:57:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e8/b81a22d9b90c00b892ccf2fa2ac36fa95de4c13ab85aea3e73795cfe4651/ruff-0.16.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:31b36f1e5ad85e0737f09d2be4e512e2e283583c14015da3b9dc07359ac0fc88", size = 9843663, upload-time = "2026-09-03T16:57:12.168Z" },
+    { url = "https://files.pythonhosted.org/packages/39/aa/54f516ec5e5a11c4afdceb1c454ebb054ffb96e4f4a1705580b4346abd35/ruff-0.16.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61029b4ab4aa723fd3064fab96b1d814492596bf0c792679fffcbde1e1679953", size = 10282461, upload-time = "2026-09-03T16:57:15.077Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0b/38d0aa8aa32372b96dc44f97b22e576c4147808271aab7b2cb1e353d4445/ruff-0.16.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9ac8998457832c2061709d900856b7ad271dace0cb41f346588d540162bfa718", size = 10728808, upload-time = "2026-09-03T16:57:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/9e274e24eeb027640ffc7442f21239f16d17f47acec15ae34f32e03a5c79/ruff-0.16.6-py3-none-win32.whl", hash = "sha256:0b87d9d16fcb63e8018423ca1d50b7260f15cb2da33e30db4baad4183a948c25", size = 10049212, upload-time = "2026-09-03T16:57:20.55Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/72472449414223ed1a2da236b992adbb1a2ae59e34794574810f60ce068e/ruff-0.16.6-py3-none-win_amd64.whl", hash = "sha256:10d21c51c3495d8eaea7b703a16592117ea6eb1d649e36335aa965ff1173eb39", size = 10556402, upload-time = "2026-09-03T16:57:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/07/d781f8f8e1ac24bef9f3269cf62ffb1407ca24c3a8f12e5e22874f90528c/ruff-0.16.6-py3-none-win_arm64.whl", hash = "sha256:7a976c79b958f94e50a022a19f0f8c87387448020935ec14fc74331bd0a7f2c5", size = 10412850, upload-time = "2026-09-03T16:57:26.416Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -939,8 +964,7 @@ wheels = [
 ]
 
 [[package]]
-name = "sigaa-ai-agent"
-version = "0.1.0"
+name = "sigaa-tools"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -953,6 +977,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "ruff" },
 ]
 mcp = [
     { name = "mcp" },
@@ -967,6 +992,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.27,<2" },
     { name = "pypdf", specifier = ">=5.0,<7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
 ]
 provides-extras = ["mcp", "dev"]
 


### PR DESCRIPTION
## What this does

Two things that ended up coupled:

1. **Restores `main`.** The recent history rewrite left `main` at `416ca2a`, 24 commits behind, missing PRs #15, #16, #17, #20 and #21. This branch carries the full rewritten history, so merging it is a fast-forward that puts those commits back.
2. **Prepares the 0.1.1 release.** Bumps the version and fixes the package URLs.

## Why 0.1.1 and not 0.1.0

`v0.1.0` was tagged but never reached PyPI. The publish run failed because the PyPI trusted publisher was registered against the pre-rename `sigaa-for-ai-agents` repo, so the OIDC claim never matched. That is now fixed on PyPI: pending publisher `sigaa-tools`, owner `PucaVaz`, repo `sigaa-tools`, workflow `publish.yml`, no environment.

The `v0.1.0` tag has been deleted from the remote, so 0.1.1 is the first real release.

## Package URLs

`project.urls` still pointed at `sigaa-for-ai-agents`. Those render on the PyPI project page, so they are updated to `sigaa-tools` and an `Issues` link is added.

## Follow-up, not in this PR

PR #18 renames `.github/workflows/publish.yml` to `cd.yml`. Trusted publishing matches on the workflow filename, so a second PyPI publisher for `cd.yml` has to be registered before that merges, or releases break again.

## Verification

- 250 tests pass
- `ruff check .` clean
- sdist and wheel build, `twine check` passes on both
- built artifacts contain only `sigaa/`, `tests/`, README, LICENSE and `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CRQbokxG3aDC6UnDC3X8G