### PR TITLE
docs: correct the install command in the privacy page

### DIFF
--- a/docs/privacidade.mdx
+++ b/docs/privacidade.mdx
@@ -71,7 +71,7 @@ exatamente o que acontece com o seu login, e pode rodar tudo na sua própria má
 O CLI faz o mesmo trabalho localmente, sem servidor nenhum:
 
 ```bash
-pipx install "sigaa-ai-agent[mcp]"
+pipx install "sigaa-tools[mcp]"
 sigaa init
 ```
 


### PR DESCRIPTION
`docs/privacidade.mdx` still told readers to run:

```bash
pipx install "sigaa-ai-agent[mcp]"
```

That is the pre-rename package name, so it fails with `No matching distribution found` even now that `sigaa-tools` 0.1.1 is on PyPI. Points it at the published name.

Related to #19.

## Also stale in this file, not changed here

The Contato link at the bottom still points at `PucaVaz/sigaa-for-ai-agents/issues`. It redirects, so it works, but it names a repo that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CRQbokxG3aDC6UnDC3X8G